### PR TITLE
Make AWS demo deploy reliable: fix Zero/Materialize handshake loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,8 @@ up-agent:
 	@echo "Waiting for agent services to be ready..."
 	@sleep 3
 	@echo ""
+	@echo "Ensuring agents container is on freshmart-network..."
+	@docker network connect freshmart-network $$($(DOCKER_COMPOSE) ps -q agents) 2>/dev/null || true
 	@echo "Initializing agent checkpointer..."
 	@$(DOCKER_COMPOSE) exec agents env PYTHONPATH=/app python -m src.init_checkpointer
 	@echo ""
@@ -159,6 +161,8 @@ up-agent-bundling:
 	@echo "Waiting for agent services to be ready..."
 	@sleep 3
 	@echo ""
+	@echo "Ensuring agents container is on freshmart-network..."
+	@docker network connect freshmart-network $$($(DOCKER_COMPOSE) ps -q agents) 2>/dev/null || true
 	@echo "Initializing agent checkpointer..."
 	@$(DOCKER_COMPOSE) exec agents env PYTHONPATH=/app python -m src.init_checkpointer
 	@echo ""

--- a/aws/deploy.sh
+++ b/aws/deploy.sh
@@ -132,16 +132,24 @@ if [[ -n "$SG_ID" ]]; then
 fi
 
 if [[ -z "$SG_ID" ]]; then
-  log "Creating security group..."
-  SG_ID=$(aws ec2 create-security-group \
-    --group-name "$TAG_NAME" \
-    --description "SSH access for live-context-graph deployment" \
-    --tag-specifications "$TAG_SPECS_SG" \
-    --query "GroupId" --output text)
-  aws ec2 authorize-security-group-ingress --group-id "$SG_ID" \
-    --protocol tcp --port 22 --cidr "${MY_IP}/32" >/dev/null
+  # Check if a security group with this name already exists in AWS (e.g. state file was lost)
+  SG_ID=$(aws ec2 describe-security-groups \
+    --filters "Name=group-name,Values=${TAG_NAME}" \
+    --query "SecurityGroups[0].GroupId" --output text 2>/dev/null)
+  if [[ "$SG_ID" == "None" || -z "$SG_ID" ]]; then
+    log "Creating security group..."
+    SG_ID=$(aws ec2 create-security-group \
+      --group-name "$TAG_NAME" \
+      --description "SSH access for live-context-graph deployment" \
+      --tag-specifications "$TAG_SPECS_SG" \
+      --query "GroupId" --output text)
+    aws ec2 authorize-security-group-ingress --group-id "$SG_ID" \
+      --protocol tcp --port 22 --cidr "${MY_IP}/32" >/dev/null
+    log "Created security group: $SG_ID (SSH from $MY_IP)"
+  else
+    log "Recovered existing security group: $SG_ID"
+  fi
   save_state "security-group-id" "$SG_ID"
-  log "Created security group: $SG_ID (SSH from $MY_IP)"
 fi
 
 # -------------------------------------------------------------------

--- a/aws/deploy.sh
+++ b/aws/deploy.sh
@@ -298,15 +298,130 @@ fi
 # Force recreate materialize-init
 REMOTE_CMD="${REMOTE_CMD} && docker compose rm -f materialize-init 2>/dev/null || true"
 
+# Wipe Zero's persisted state so it boots clean against a freshly-initialized
+# Materialize. Materialize has no volume (see compose) so its state resets every
+# deploy; zero-cache's replica.db is now ephemeral (no named volume) but the
+# zero_change/zero_cvr metadata DBs live in app_postgres_data and must be reset
+# explicitly, or zero-cache will crash-loop on stale watermarks.
+REMOTE_CMD="${REMOTE_CMD} && docker compose rm -fsv zero-cache materialize-zero zero-permissions 2>/dev/null || true"
+REMOTE_CMD="${REMOTE_CMD} && docker volume rm app_zero_data 2>/dev/null || true"
+REMOTE_CMD="${REMOTE_CMD} && docker compose up -d --wait db"
+REMOTE_CMD="${REMOTE_CMD} && docker compose exec -T db psql -U postgres -c \"DROP DATABASE IF EXISTS zero_change WITH (FORCE);\""
+REMOTE_CMD="${REMOTE_CMD} && docker compose exec -T db psql -U postgres -c \"DROP DATABASE IF EXISTS zero_cvr WITH (FORCE);\""
+REMOTE_CMD="${REMOTE_CMD} && docker compose exec -T db psql -U postgres -c \"CREATE DATABASE zero_change;\""
+REMOTE_CMD="${REMOTE_CMD} && docker compose exec -T db psql -U postgres -c \"CREATE DATABASE zero_cvr;\""
+
 # Run the compose command
 REMOTE_CMD="${REMOTE_CMD} && ${COMPOSE_CMD}"
 
-COMPOSE_OUTPUT=$(ssh $SSH_OPTS ec2-user@"$PUBLIC_IP" "$REMOTE_CMD" 2>&1) || {
-    echo "Error: Docker Compose deployment failed:"
-    echo "$COMPOSE_OUTPUT"
+ssh $SSH_OPTS ec2-user@"$PUBLIC_IP" "$REMOTE_CMD" || {
+    echo "Error: Docker Compose deployment failed"
     exit 1
   }
 log "Docker Compose stack deployed."
+
+# Stabilize the Zero stack against Materialize. Two failure modes can drive
+# zero-cache into an AutoResetSignal loop that does not self-recover:
+#   1. zero-cache subscribes before materialize-zero has finished hydrating
+#      its collections — gated by mz_internal.mz_hydration_statuses below.
+#   2. materialize-zero asks Materialize for a timestamp mz has compacted past
+#      (OutOfBoundsTimestampError) — typically a transient timestamp-oracle
+#      skew when materialize-zero connects shortly after a fresh boot.
+# We handle (1) with the hydration gate and (2) with a one-shot self-heal:
+# if zero-cache is restart-looping, we drop the metadata DBs, recreate the
+# whole Zero stack, wait for hydration again, and re-check stability. Two
+# attempts is enough — if it still loops, the deploy fails loud.
+log "Stabilizing Zero stack..."
+ssh $SSH_OPTS ec2-user@"$PUBLIC_IP" bash <<'EOF' || { echo "Error: zero-cache could not be stabilized"; exit 1; }
+set -e
+cd ~/app
+
+COLLECTIONS="orders_flat_mv,courier_schedule_mv,customers_mv,orders_search_source_mv,products_mv,store_inventory_mv,stores_mv,orders_with_lines_mv,inventory_items_with_dynamic_pricing_mv,pricing_yield_mv,inventory_risk_mv,store_capacity_health_mv,delivery_bundles_mv,compatible_pairs_mv"
+EXPECTED=$(echo "$COLLECTIONS" | tr ',' '\n' | wc -l | tr -d ' ')
+QUOTED=$(echo "$COLLECTIONS" | sed "s/,/','/g; s/^/'/; s/$/'/")
+HYDRATION_SQL="SELECT count(*) FROM mz_internal.mz_hydration_statuses hs JOIN mz_catalog.mz_materialized_views mv ON mv.id = hs.object_id WHERE mv.name IN ($QUOTED) AND hs.hydrated;"
+
+wait_for_hydration() {
+  echo "Waiting for $EXPECTED Materialize views to hydrate..."
+  local i hydrated=0
+  for i in $(seq 1 60); do
+    sleep 5
+    hydrated=$(docker compose exec -T mz psql -h localhost -p 6875 -U materialize -d materialize -tAc "$HYDRATION_SQL" 2>/dev/null | tr -d ' \r\n' || echo 0)
+    if [ "$hydrated" = "$EXPECTED" ]; then
+      echo "  All $EXPECTED views hydrated after $((i*5))s"
+      return 0
+    fi
+  done
+  echo "  ERROR: only $hydrated/$EXPECTED views hydrated after 300s"
+  docker compose exec -T mz psql -h localhost -p 6875 -U materialize -d materialize -c "SELECT mv.name, hs.hydrated FROM mz_internal.mz_hydration_statuses hs RIGHT JOIN mz_catalog.mz_materialized_views mv ON mv.id = hs.object_id WHERE mv.name IN ($QUOTED) ORDER BY mv.name;" || true
+  return 1
+}
+
+reset_zero_stack() {
+  echo "Resetting Zero stack (containers + metadata DBs)..."
+  docker compose rm -fsv zero-cache materialize-zero zero-permissions 2>/dev/null || true
+  docker compose exec -T db psql -U postgres -c "DROP DATABASE IF EXISTS zero_change WITH (FORCE);" >/dev/null
+  docker compose exec -T db psql -U postgres -c "DROP DATABASE IF EXISTS zero_cvr WITH (FORCE);" >/dev/null
+  docker compose exec -T db psql -U postgres -c "CREATE DATABASE zero_change;" >/dev/null
+  docker compose exec -T db psql -U postgres -c "CREATE DATABASE zero_cvr;" >/dev/null
+  docker compose up -d materialize-zero zero-cache zero-permissions
+}
+
+clear_reset_flag() {
+  # zero-cache's auto-reset path sets resetRequired=true in zero_change on
+  # every reset-required signal it receives, and reads it on every restart
+  # WITHOUT clearing it. Once set, zero-cache enters an infinite
+  # AutoResetSignal loop that doesn't self-recover even after the upstream
+  # cause is fixed. Clear it before each (re)start.
+  docker compose exec -T db psql -U postgres -d zero_change -c \
+    'UPDATE "zero_0/cdc"."replicationConfig" SET "resetRequired" = false;' \
+    >/dev/null 2>&1 || true
+}
+
+recreate_zero_cache() {
+  echo "Recreating zero-cache against hydrated upstream..."
+  docker compose rm -fsv zero-cache >/dev/null
+  clear_reset_flag
+  docker compose up -d zero-cache >/dev/null
+}
+
+verify_stability() {
+  # Watch for restarts over 60s. A delta > 1 indicates an AutoResetSignal loop
+  # (the WebSocket failure mode that appears in the browser as
+  # "WebSocket connection closed abruptly" at ws://localhost:4848).
+  echo "Verifying zero-cache stability..."
+  local before now delta i
+  sleep 5  # let the new container settle
+  before=$(docker inspect -f '{{.RestartCount}}' zero-cache 2>/dev/null || echo 0)
+  for i in $(seq 1 12); do
+    sleep 5
+    now=$(docker inspect -f '{{.RestartCount}}' zero-cache 2>/dev/null || echo 0)
+    delta=$((now - before))
+    if [ "$delta" -gt 1 ]; then
+      echo "  zero-cache restarted $delta times in $((i*5))s — unstable"
+      return 1
+    fi
+  done
+  echo "  zero-cache stable (delta=$delta after 60s)"
+  return 0
+}
+
+# Attempt 1: wait for hydration, recreate zero-cache, check stability.
+wait_for_hydration || exit 1
+recreate_zero_cache
+verify_stability && exit 0
+
+# Attempt 2: full Zero-stack reset (covers OutOfBoundsTimestampError and other
+# transient handshake failures that don't self-recover within 60s).
+echo "Stability check failed — performing full Zero-stack reset and retrying"
+reset_zero_stack
+wait_for_hydration || exit 1
+verify_stability && exit 0
+
+echo "ERROR: zero-cache could not stabilize after 2 attempts"
+docker compose logs --tail=80 zero-cache
+exit 1
+EOF
 
 log "Waiting for databases to be ready..."
 sleep 10

--- a/aws/user-data.sh
+++ b/aws/user-data.sh
@@ -32,5 +32,12 @@ chmod +x /usr/local/lib/docker/cli-plugins/docker-buildx
 # Add ec2-user to docker group
 usermod -aG docker ec2-user
 
+# Raise vm.max_map_count for OpenSearch. AL2023's default (65530) is below the
+# 262144 OpenSearch requires; without this, OpenSearch's bootstrap precheck
+# fails and its error output gets concatenated into JAVA_OPTS, which makes the
+# JVM die with a misleading "Could not find or load main class Cannot" error.
+sysctl -w vm.max_map_count=262144
+echo "vm.max_map_count=262144" > /etc/sysctl.d/99-opensearch.conf
+
 # Signal that user-data script is complete
 touch /tmp/user-data-complete

--- a/db/materialize/init.sh
+++ b/db/materialize/init.sh
@@ -96,10 +96,15 @@ CREATE SOURCE IF NOT EXISTS pg_source
     IN CLUSTER ingest
     FROM POSTGRES CONNECTION pg_connection (PUBLICATION 'mz_source');"
 
-# Create table from source (new v26 syntax, replaces FOR ALL TABLES)
+# Create table from source (new v26 syntax, replaces FOR ALL TABLES).
+# RETAIN HISTORY 5min is required so SUBSCRIBEs from materialize-zero don't
+# fail with `Timestamp not valid for all inputs`. ALTER TABLE doesn't work
+# on source-derived tables (mz bug — planner accepts but catalog rejects),
+# so retention must be set at CREATE time.
 psql -h "$MZ_HOST" -p "$MZ_PORT" -U materialize -c "
 CREATE TABLE IF NOT EXISTS triples
-    FROM SOURCE pg_source (REFERENCE public.triples);"
+    FROM SOURCE pg_source (REFERENCE public.triples)
+    WITH (RETAIN HISTORY FOR '5 minutes');"
 
 echo "Waiting for source to hydrate..."
 sleep 5
@@ -1588,6 +1593,16 @@ echo "Setting RETAIN HISTORY for materialize-zero compatibility..."
 # docker-compose.yml).
 psql -h "$MZ_HOST" -p "$MZ_PORT" -U materialize <<'SQL'
 ALTER SOURCE pg_source SET (RETAIN HISTORY FOR '5 minutes');
+-- Intermediate MVs: these aren't subscribed by materialize-zero directly,
+-- but the leaf MVs depend on them, so their `since` constrains the
+-- timestamp validity check (`Timestamp not valid for all inputs`).
+ALTER MATERIALIZED VIEW order_lines_flat_mv SET (RETAIN HISTORY FOR '5 minutes');
+ALTER MATERIALIZED VIEW store_courier_metrics_mv SET (RETAIN HISTORY FOR '5 minutes');
+ALTER MATERIALIZED VIEW store_metrics_by_window_mv SET (RETAIN HISTORY FOR '5 minutes');
+ALTER MATERIALIZED VIEW store_metrics_timeseries_mv SET (RETAIN HISTORY FOR '5 minutes');
+ALTER MATERIALIZED VIEW store_wait_time_by_window_mv SET (RETAIN HISTORY FOR '5 minutes');
+ALTER MATERIALIZED VIEW system_metrics_timeseries_mv SET (RETAIN HISTORY FOR '5 minutes');
+-- Leaf MVs that materialize-zero subscribes to:
 ALTER MATERIALIZED VIEW orders_flat_mv SET (RETAIN HISTORY FOR '5 minutes');
 ALTER MATERIALIZED VIEW courier_schedule_mv SET (RETAIN HISTORY FOR '5 minutes');
 ALTER MATERIALIZED VIEW customers_mv SET (RETAIN HISTORY FOR '5 minutes');

--- a/db/materialize/init.sh
+++ b/db/materialize/init.sh
@@ -1568,6 +1568,42 @@ else
     psql -h "$MZ_HOST" -p "$MZ_PORT" -U materialize -c "CREATE INDEX IF NOT EXISTS compatible_pairs_pk_idx IN CLUSTER serving ON compatible_pairs_mv (order_a, order_b);"
 fi
 
+echo "Setting RETAIN HISTORY for materialize-zero compatibility..."
+# Without this, materialized views default to RETAIN HISTORY = 1s. When
+# zero-cache reconnects to the materialize-zero sidecar with a stored
+# lastWatermark older than 1s (which happens routinely during the burst of
+# ~14 simultaneous subscribes at boot, or after any zero-cache restart), mz
+# rejects the AS OF and the sidecar's error path sends `reset-required` to
+# zero-cache, which exits 14 (auto-reset). The cycle repeats indefinitely.
+#
+# The fix has to apply to the WHOLE dependency chain — Materialize's
+# `Timestamp (X) is not valid for all inputs` error is raised when the chosen
+# AS OF is below the `since` of *any* upstream collection, not just the leaf
+# MV. Setting retention only on the leaf MVs leaves pg_source at the default
+# 1s window and the loop continues. We set it on the postgres source AND the
+# 14 leaf MVs the sidecar subscribes to.
+#
+# Five minutes is comfortably longer than any reasonable resubscribe round-trip.
+# enable_logical_compaction_window must be on (set in the mz command in
+# docker-compose.yml).
+psql -h "$MZ_HOST" -p "$MZ_PORT" -U materialize <<'SQL'
+ALTER SOURCE pg_source SET (RETAIN HISTORY FOR '5 minutes');
+ALTER MATERIALIZED VIEW orders_flat_mv SET (RETAIN HISTORY FOR '5 minutes');
+ALTER MATERIALIZED VIEW courier_schedule_mv SET (RETAIN HISTORY FOR '5 minutes');
+ALTER MATERIALIZED VIEW customers_mv SET (RETAIN HISTORY FOR '5 minutes');
+ALTER MATERIALIZED VIEW orders_search_source_mv SET (RETAIN HISTORY FOR '5 minutes');
+ALTER MATERIALIZED VIEW products_mv SET (RETAIN HISTORY FOR '5 minutes');
+ALTER MATERIALIZED VIEW store_inventory_mv SET (RETAIN HISTORY FOR '5 minutes');
+ALTER MATERIALIZED VIEW stores_mv SET (RETAIN HISTORY FOR '5 minutes');
+ALTER MATERIALIZED VIEW orders_with_lines_mv SET (RETAIN HISTORY FOR '5 minutes');
+ALTER MATERIALIZED VIEW inventory_items_with_dynamic_pricing_mv SET (RETAIN HISTORY FOR '5 minutes');
+ALTER MATERIALIZED VIEW pricing_yield_mv SET (RETAIN HISTORY FOR '5 minutes');
+ALTER MATERIALIZED VIEW inventory_risk_mv SET (RETAIN HISTORY FOR '5 minutes');
+ALTER MATERIALIZED VIEW store_capacity_health_mv SET (RETAIN HISTORY FOR '5 minutes');
+ALTER MATERIALIZED VIEW delivery_bundles_mv SET (RETAIN HISTORY FOR '5 minutes');
+ALTER MATERIALIZED VIEW compatible_pairs_mv SET (RETAIN HISTORY FOR '5 minutes');
+SQL
+
 echo "Verifying three-tier setup..."
 echo ""
 echo "=== Clusters ==="

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,7 +119,11 @@ services:
           ZERO_ADMIN_PASSWORD: "admin"
           ZERO_LOG_LEVEL: "info"
       volumes:
-          - zero_data:/data
+          # Anonymous volume — gives /data a writable spot for replica.db
+          # without persisting across container recreates. deploy.sh's
+          # `docker compose rm -fsv zero-cache` clears it on every deploy,
+          # keeping zero-cache in sync with Materialize's ephemeral state.
+          - /data
       ports:
           - "4848:4848"
 
@@ -136,7 +140,7 @@ services:
           MATERIALIZE_AUTH_OPTIONS_USER: ${MZ_USER:-materialize}
           MATERIALIZE_AUTH_OPTIONS_PASSWORD: ${MZ_PASSWORD:-materialize}
           MATERIALIZE_DATABASE: ${MZ_DATABASE:-materialize}
-          MATERIALIZE_COLLECTIONS: "orders_flat_mv,courier_schedule_mv,customers_mv,orders_search_source_mv,products_mv,store_inventory_mv,stores_mv,orders_with_lines_mv,inventory_items_with_dynamic_pricing,pricing_yield_mv,inventory_risk_mv,store_capacity_health_mv,delivery_bundles_mv,compatible_pairs_mv"
+          MATERIALIZE_COLLECTIONS: "orders_flat_mv,courier_schedule_mv,customers_mv,orders_search_source_mv,products_mv,store_inventory_mv,stores_mv,orders_with_lines_mv,inventory_items_with_dynamic_pricing_mv,pricing_yield_mv,inventory_risk_mv,store_capacity_health_mv,delivery_bundles_mv,compatible_pairs_mv"
           PORT: 8080
           LOG_LEVEL: ${LOG_LEVEL:-INFO}
           NODE_ENV: production
@@ -345,7 +349,6 @@ services:
 volumes:
   postgres_data:
   opensearch_data:
-  zero_data:
 
 networks:
   default:

--- a/web/src/components/OrderFormModal.tsx
+++ b/web/src/components/OrderFormModal.tsx
@@ -73,8 +73,8 @@ export function OrderFormModal({
 
   // Query inventory for the selected store (needed for accurate stock levels when editing)
   const inventoryQuery = formData.store_id
-    ? z.query.inventory_items_with_dynamic_pricing.where('store_id', '=', formData.store_id)
-    : z.query.inventory_items_with_dynamic_pricing.where('store_id', '=', '__none__');
+    ? z.query.inventory_items_with_dynamic_pricing_mv.where('store_id', '=', formData.store_id)
+    : z.query.inventory_items_with_dynamic_pricing_mv.where('store_id', '=', '__none__');
   const [inventoryData] = useQuery(inventoryQuery);
 
   // Calculate total from line items

--- a/web/src/components/ProductSelector.tsx
+++ b/web/src/components/ProductSelector.tsx
@@ -27,7 +27,7 @@ export function ProductSelector({ storeId, onProductSelect, disabled }: ProductS
   const z = useZero<Schema>()
 
   // Query inventory with dynamic pricing for the selected store
-  let inventoryQuery = z.query.inventory_items_with_dynamic_pricing
+  let inventoryQuery = z.query.inventory_items_with_dynamic_pricing_mv
   if (storeId) {
     inventoryQuery = inventoryQuery.where('store_id', '=', storeId)
   }

--- a/web/src/pages/OrdersDashboardPage.tsx
+++ b/web/src/pages/OrdersDashboardPage.tsx
@@ -274,8 +274,8 @@ function LineItemsTable({ lineItems, storeId }: { lineItems: OrderLineItem[]; st
 
   // Query current inventory for this store to get live prices
   const inventoryQuery = storeId
-    ? z.query.inventory_items_with_dynamic_pricing.where('store_id', '=', storeId)
-    : z.query.inventory_items_with_dynamic_pricing.where('store_id', '=', '__none__');
+    ? z.query.inventory_items_with_dynamic_pricing_mv.where('store_id', '=', storeId)
+    : z.query.inventory_items_with_dynamic_pricing_mv.where('store_id', '=', '__none__');
   const [inventoryData] = useQuery(inventoryQuery);
 
   // Build lookup map for current prices by product_id

--- a/web/src/pages/QueryStatisticsPage.tsx
+++ b/web/src/pages/QueryStatisticsPage.tsx
@@ -557,8 +557,8 @@ export default function QueryStatisticsPage() {
   // Query inventory pricing for the store (real-time from Materialize)
   const storeId = zeroOrder?.searchData?.store_id || zeroOrder?.store_id;
   const pricingQuery = useMemo(() => {
-    if (!storeId) return z.query.inventory_items_with_dynamic_pricing.where("store_id", "=", EMPTY_QUERY_SENTINEL);
-    return z.query.inventory_items_with_dynamic_pricing.where("store_id", "=", storeId);
+    if (!storeId) return z.query.inventory_items_with_dynamic_pricing_mv.where("store_id", "=", EMPTY_QUERY_SENTINEL);
+    return z.query.inventory_items_with_dynamic_pricing_mv.where("store_id", "=", storeId);
   }, [z, storeId]);
 
   const [zeroPricingData] = useQuery(pricingQuery);

--- a/web/src/schema.ts
+++ b/web/src/schema.ts
@@ -154,8 +154,8 @@ const products_mv = table('products_mv')
   })
   .primaryKey('product_id')
 
-// inventory_items_with_dynamic_pricing - inventory with live pricing
-const inventory_items_with_dynamic_pricing = table('inventory_items_with_dynamic_pricing')
+// inventory_items_with_dynamic_pricing_mv - inventory with live pricing
+const inventory_items_with_dynamic_pricing = table('inventory_items_with_dynamic_pricing_mv')
   .columns({
     inventory_id: string(),
     store_id: string().optional(),
@@ -319,7 +319,7 @@ export const permissions = definePermissions<unknown, Schema>(schema, () => ({
   courier_schedule_mv: publicRead,
   customers_mv: publicRead,
   products_mv: publicRead,
-  inventory_items_with_dynamic_pricing: publicRead,
+  inventory_items_with_dynamic_pricing_mv: publicRead,
   pricing_yield_mv: publicRead,
   inventory_risk_mv: publicRead,
   store_capacity_health_mv: publicRead,

--- a/zero-permissions/update-permissions.ts
+++ b/zero-permissions/update-permissions.ts
@@ -70,6 +70,21 @@ async function updatePermissions(): Promise<void> {
         // Step 1: Wait for the permissions table to be created by materialize-zero
         await waitForPermissionsTable();
 
+        // Step 1b: Set RETAIN HISTORY on zero.permissions. The materialize-zero
+        // sidecar subscribes to it as a system collection on every zero-cache
+        // (re)connect. With the default 1s retention, any reconnect after a
+        // brief gap hits OutOfBoundsTimestampError, which the sidecar surfaces
+        // as `reset-required`, which sets resetRequired=true in zero_change
+        // and traps zero-cache in an infinite AutoResetSignal loop.
+        {
+            const retentionClient = new Client({ connectionString: getConnectionString() });
+            await retentionClient.connect();
+            console.log("Setting RETAIN HISTORY on zero.permissions...");
+            await retentionClient.query(`ALTER TABLE "zero.permissions" SET (RETAIN HISTORY FOR '5 minutes')`);
+            await retentionClient.end();
+            console.log('✓ RETAIN HISTORY set on zero.permissions.');
+        }
+
         // Step 2: Create a temp directory
         tempDir = mkdtempSync(join(tmpdir(), 'permissions-'));
         const outputFile = join(tempDir, 'perm.json');


### PR DESCRIPTION
## Summary

End-to-end fixes for `make up-agent-aws` so the demo comes up cleanly on a fresh EC2 instance and survives subsequent deploys without the `WebSocket connection closed abruptly` failures at `ws://localhost:4848` that were appearing in the browser console.

## Root cause

zero-cache was crash-looping on `AutoResetSignal` because materialize-zero responded `reset-required` on every reconnect. The actual mz error under the hood was `Timestamp (X) is not valid for all inputs: []`, which the sidecar misclassifies as `OutOfBoundsTimestampError` and surfaces by setting `resetRequired=true` in `zero_change` — trapping zero-cache in an infinite reset loop.

mz raises that error when `AS OF` is below the `since` of **any** upstream in the dependency chain, not just the leaf MV. We were only setting `RETAIN HISTORY` on the 14 leaf MVs — and even those weren't actually wired up: `db/materialize/init_materialize.sql` was dead code never sourced by `init.sh`. The Postgres source's default 1-second retention was the real gate.

## Failure modes resolved

1. **Zero/Materialize subscribe loop.** Wire `init_materialize.sql`'s ALTERs into `init.sh`, add `ALTER SOURCE pg_source SET (RETAIN HISTORY FOR '5 minutes')`, and apply the same to `zero.permissions` inside `update-permissions.ts` so it's set right after the table is created.
2. **`MATERIALIZE_COLLECTIONS` typo.** `inventory_items_with_dynamic_pricing` was missing the `_mv` suffix — sidecar was subscribing to a non-existent collection.
3. **OpenSearch fails to start on AL2023.** Default `vm.max_map_count` (65530) is below OpenSearch's required 262144. The bootstrap precheck fails and concatenates "Cannot..." into JAVA_OPTS, producing the misleading `Could not find or load main class Cannot` error. Now baked into `user-data.sh`.
4. **Silent deploy failures.** Deploy used to print "Deployment complete!" while zero-cache was crash-looping. `deploy.sh` now:
   - Streams `docker compose up` output instead of buffering it.
   - Drops/recreates `zero_change` and `zero_cvr` at the start of every deploy.
   - Polls `mz_internal.mz_hydration_statuses` (5 min timeout) before starting zero-cache.
   - Verifies stability via RestartCount delta over 60s; on instability, performs one full Zero-stack reset and re-checks. Fails the deploy loud if still unstable.
   - Clears the sticky `resetRequired` flag before each zero-cache (re)start.
5. **Compose hardening.** `zero-cache`'s named volume becomes anonymous so `docker compose rm` always wipes stale `replica.db` state, matching the Zero metadata DBs that also reset on every deploy.

## Files

- `aws/deploy.sh` — hydration gate, stability check + self-heal retry, `clear_reset_flag` helper, streaming output
- `aws/user-data.sh` — `vm.max_map_count=262144` baked into instance bootstrap
- `db/materialize/init.sh` — ALTERs wired in for `pg_source` + 14 MVs
- `docker-compose.yml` — typo fix, anonymous volume on `zero-cache`
- `zero-permissions/update-permissions.ts` — RETAIN HISTORY on `zero.permissions` table

## Test plan

- [ ] `make down-aws && make up-agent-aws` from a fresh state: deploy completes without errors, zero-cache stability check passes
- [ ] Browser smoke at http://localhost:5173: 0 console WebSocket failures, all pages render live data
- [ ] `docker compose -f ~/app/docker-compose.yml exec mz psql -h localhost -p 6875 -U materialize -d materialize -c "SELECT name, value FROM mz_internal.mz_history_retention_strategies hr JOIN (SELECT id, name FROM mz_catalog.mz_sources UNION ALL SELECT id, name FROM mz_catalog.mz_materialized_views UNION ALL SELECT id, name FROM mz_catalog.mz_tables WHERE name='zero.permissions') o ON o.id = hr.id;"` — confirm `pg_source`, all 14 MVs, and `zero.permissions` show `300000`
- [ ] Verify zero-cache `RestartCount` stays flat for ≥5 minutes after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)