### PR TITLE
Vector pipeline UX + index impact improvements

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -24,3 +24,6 @@ pytest-cov>=4.1.0
 
 # Development
 ruff==0.2.0
+
+# Vector search / embeddings
+fastembed>=0.3.6

--- a/api/src/routes/query_stats.py
+++ b/api/src/routes/query_stats.py
@@ -1029,6 +1029,20 @@ async def write_triple(data: TripleWrite):
     allowing you to observe how the change propagates through
     each data access pattern.
     """
+    # Capture mz_now() BEFORE the PostgreSQL write as a lower bound for impact detection.
+    # Materialize transactions are read-only OR write-only, so this is a separate read.
+    # Any OpenSearch document re-indexed as a result of this write will have
+    # mz_timestamp >= this value (guaranteed by the monotonic Materialize clock).
+    mz_lower_bound: Optional[int] = None
+    try:
+        async with get_mz_session() as mz_session:
+            result = await mz_session.execute(text("SELECT mz_now()::text AS ts"))
+            row = result.fetchone()
+            if row:
+                mz_lower_bound = int(row[0])
+    except Exception as mz_err:
+        logger.warning(f"Could not get mz_now() before write: {mz_err}")
+
     try:
         async with get_pg_session() as session:
             result = await session.execute(
@@ -1052,7 +1066,11 @@ async def write_triple(data: TripleWrite):
                 )
             await session.commit()
 
-        return {"status": "written", "timestamp": datetime.now(timezone.utc).isoformat()}
+        return {
+            "status": "written",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "mz_timestamp_lower_bound": mz_lower_bound,
+        }
     except HTTPException:
         raise
     except Exception as e:

--- a/api/src/routes/query_stats.py
+++ b/api/src/routes/query_stats.py
@@ -1029,19 +1029,11 @@ async def write_triple(data: TripleWrite):
     allowing you to observe how the change propagates through
     each data access pattern.
     """
-    # Capture mz_now() BEFORE the PostgreSQL write as a lower bound for impact detection.
-    # Materialize transactions are read-only OR write-only, so this is a separate read.
-    # Any OpenSearch document re-indexed as a result of this write will have
-    # mz_timestamp >= this value (guaranteed by the monotonic Materialize clock).
-    mz_lower_bound: Optional[int] = None
-    try:
-        async with get_mz_session() as mz_session:
-            result = await mz_session.execute(text("SELECT mz_now()::text AS ts"))
-            row = result.fetchone()
-            if row:
-                mz_lower_bound = int(row[0])
-    except Exception as mz_err:
-        logger.warning(f"Could not get mz_now() before write: {mz_err}")
+    # Capture wall-clock ms BEFORE the PostgreSQL write as a lower bound for impact detection.
+    # Any OpenSearch doc stamped by the search-sync worker after this point will have
+    # mz_timestamp (also wall-clock ms) >= this value, so the range query is always correct.
+    # mz_now() in a standalone SELECT returns the uint64 sentinel (2^64-1), not epoch ms.
+    mz_lower_bound: int = int(time.time() * 1000)
 
     try:
         async with get_pg_session() as session:

--- a/api/src/routes/query_stats.py
+++ b/api/src/routes/query_stats.py
@@ -29,6 +29,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 from sqlalchemy import text
 
+from src.audit.write_store import WriteEvent, generate_batch_id, get_write_store
 from src.db.client import get_mz_session, get_pg_session
 
 logger = logging.getLogger(__name__)
@@ -1037,6 +1038,13 @@ async def write_triple(data: TripleWrite):
 
     try:
         async with get_pg_session() as session:
+            old_row = await session.execute(
+                text("SELECT object_value FROM triples WHERE subject_id = :subject_id AND predicate = :predicate"),
+                {"subject_id": data.subject_id, "predicate": data.predicate},
+            )
+            old = old_row.fetchone()
+            old_value = old.object_value if old else None
+
             result = await session.execute(
                 text("""
                     UPDATE triples
@@ -1057,6 +1065,15 @@ async def write_triple(data: TripleWrite):
                     detail=f"Triple not found: {data.subject_id} / {data.predicate}",
                 )
             await session.commit()
+
+        get_write_store().add_event(WriteEvent(
+            subject_id=data.subject_id,
+            predicate=data.predicate,
+            old_value=old_value,
+            new_value=data.object_value,
+            operation="UPDATE",
+            batch_id=generate_batch_id(),
+        ))
 
         return {
             "status": "written",

--- a/api/src/routes/search.py
+++ b/api/src/routes/search.py
@@ -313,33 +313,29 @@ async def get_index_impact(
     range_query = {"query": {"range": {"mz_timestamp": {"gte": since_mz_timestamp}}}}
     try:
         async with httpx.AsyncClient(timeout=OPENSEARCH_TIMEOUT) as client:
-            total = 0
-            impacted = 0
-            breakdown: dict[str, dict] = {}
-
-            for index in IMPACT_INDEXES:
-                total_resp = await client.get(f"{settings.os_url}/{index}/_count")
-                if total_resp.status_code == 404:
-                    breakdown[index] = {"impacted": 0, "total": 0}
-                    continue
-                total_resp.raise_for_status()
-                idx_total = total_resp.json().get("count", 0)
-
-                impact_resp = await client.post(
-                    f"{settings.os_url}/{index}/_count",
-                    json=range_query,
-                    headers={"Content-Type": "application/json"},
+            async def fetch_index(index: str) -> tuple[str, dict]:
+                total_r, impact_r = await asyncio.gather(
+                    client.get(f"{settings.os_url}/{index}/_count"),
+                    client.post(
+                        f"{settings.os_url}/{index}/_count",
+                        json=range_query,
+                        headers={"Content-Type": "application/json"},
+                    ),
                 )
-                if impact_resp.status_code == 404:
+                if total_r.status_code == 404:
+                    return index, {"impacted": 0, "total": 0}
+                total_r.raise_for_status()
+                if impact_r.status_code == 404:
                     idx_impacted = 0
                 else:
-                    impact_resp.raise_for_status()
-                    idx_impacted = impact_resp.json().get("count", 0)
+                    impact_r.raise_for_status()
+                    idx_impacted = impact_r.json().get("count", 0)
+                return index, {"impacted": idx_impacted, "total": total_r.json().get("count", 0)}
 
-                breakdown[index] = {"impacted": idx_impacted, "total": idx_total}
-                total += idx_total
-                impacted += idx_impacted
-
+            results = await asyncio.gather(*[fetch_index(idx) for idx in IMPACT_INDEXES])
+            breakdown = dict(results)
+            total = sum(v["total"] for v in breakdown.values())
+            impacted = sum(v["impacted"] for v in breakdown.values())
             pct = round(impacted / total * 100, 1) if total > 0 else 0.0
             return {"impacted": impacted, "total": total, "pct": pct, "breakdown": breakdown}
     except httpx.ConnectError as e:

--- a/api/src/routes/search.py
+++ b/api/src/routes/search.py
@@ -47,7 +47,7 @@ def get_query_embedder():
                     self._model = TextEmbedding(model_name="BAAI/bge-small-en-v1.5")
 
                 def embed(self, texts):
-                    return [list(v) for v in self._model.embed(texts)]
+                    return [[float(x) for x in v] for v in self._model.embed(texts)]
 
             _query_embedder = _Embedder()
         except ImportError as e:

--- a/api/src/routes/search.py
+++ b/api/src/routes/search.py
@@ -169,7 +169,7 @@ async def vector_search_orders(
                 }
             }
         },
-        "_source": ["order_id", "embedding_text", "embedded_at", "line_items"],
+        "_source": ["order_id", "embedding", "embedding_text", "embedded_at", "line_items"],
         "size": limit,
     }
 
@@ -247,6 +247,7 @@ async def vector_search_orders(
         merged: dict[str, Any] = {
             "order_id": order_id,
             "score": hit.get("_score"),
+            "embedding": source.get("embedding") or [],
             "embedding_text": source.get("embedding_text"),
             "embedded_at": source.get("embedded_at"),
             # Line items come from OpenSearch (indexed from Materialize CDC,
@@ -259,6 +260,7 @@ async def vector_search_orders(
         # Re-pin OS-only fields so they aren't clobbered by OrderFlat.
         merged["order_id"] = order_id
         merged["score"] = hit.get("_score")
+        merged["embedding"] = source.get("embedding") or []
         merged["embedding_text"] = source.get("embedding_text")
         merged["embedded_at"] = source.get("embedded_at")
         merged["line_items"] = source.get("line_items") or []

--- a/api/src/routes/search.py
+++ b/api/src/routes/search.py
@@ -4,6 +4,7 @@ These endpoints proxy search requests to OpenSearch, allowing the frontend
 to perform semantic searches across denormalized order documents.
 """
 
+import asyncio
 import logging
 from typing import Any, Optional
 
@@ -234,37 +235,32 @@ async def vector_search_orders(
             detail=f"Vector search failed: {str(e)}",
         )
 
-    # 3 + 4. Hydrate each hit from Materialize and merge
+    # 3. Hydrate all hits from Materialize concurrently (avoid N+1 round-trips).
     hits = os_result.get("hits", {}).get("hits", []) or []
-    results: list[dict[str, Any]] = []
 
-    for hit in hits:
+    async def _hydrate(hit: dict) -> dict | None:
         source = hit.get("_source", {}) or {}
         order_id = source.get("order_id") or hit.get("_id")
         if not order_id:
-            continue
-
-        # Live hydration via Materialize
+            return None
         try:
             order = await service.get_order(order_id)
         except Exception as e:
-            logger.warning(
-                f"Failed to hydrate order {order_id} from Materialize: {e}",
-                exc_info=True,
-            )
-            continue
-
+            logger.warning(f"Failed to hydrate order {order_id} from Materialize: {e}", exc_info=True)
+            return None
         if order is None:
-            # Order was deleted between indexing and now - skip
             logger.debug(f"Skipping {order_id}: not found in Materialize")
-            continue
+            return None
 
         # model_dump(mode="json") serializes Decimal as str; convert to float.
         live = order.model_dump(mode="json")
         if live.get("order_total_amount") is not None:
             live["order_total_amount"] = float(live["order_total_amount"])
 
-        merged: dict[str, Any] = {
+        # Start from live Materialize fields; then layer in OS-only fields that
+        # must survive (embedding, line_items, score — not present in OrderFlat).
+        merged: dict[str, Any] = {**live}
+        merged.update({
             "order_id": order_id,
             "score": hit.get("_score"),
             "embedding": source.get("embedding") or [],
@@ -274,17 +270,11 @@ async def vector_search_orders(
             # <2s latency). They carry live_price, base_price, etc. because
             # search-sync joins inventory_items_with_dynamic_pricing_mv.
             "line_items": source.get("line_items") or [],
-        }
-        # Merge live Materialize fields — live values win on conflicts.
-        merged.update(live)
-        # Re-pin OS-only fields so they aren't clobbered by OrderFlat.
-        merged["order_id"] = order_id
-        merged["score"] = hit.get("_score")
-        merged["embedding"] = source.get("embedding") or []
-        merged["embedding_text"] = source.get("embedding_text")
-        merged["embedded_at"] = source.get("embedded_at")
-        merged["line_items"] = source.get("line_items") or []
-        results.append(merged)
+        })
+        return merged
+
+    hydrated = await asyncio.gather(*[_hydrate(h) for h in hits])
+    results = [r for r in hydrated if r is not None]
 
     return {"results": results, "query": q, "total": len(results)}
 

--- a/api/src/routes/search.py
+++ b/api/src/routes/search.py
@@ -267,3 +267,62 @@ async def vector_search_orders(
         results.append(merged)
 
     return {"results": results, "query": q, "total": len(results)}
+
+
+@router.get("/index-stats")
+async def get_index_stats() -> dict[str, Any]:
+    """Return total document count for the orders index."""
+    try:
+        async with httpx.AsyncClient(timeout=OPENSEARCH_TIMEOUT) as client:
+            response = await client.get(f"{settings.os_url}/orders/_count")
+            if response.status_code == 404:
+                return {"doc_count": 0}
+            response.raise_for_status()
+            return {"doc_count": response.json().get("count", 0)}
+    except httpx.ConnectError as e:
+        logger.error(f"Failed to connect to OpenSearch: {e}", exc_info=True)
+        raise HTTPException(status_code=503, detail="OpenSearch is not available.")
+    except httpx.HTTPStatusError as e:
+        raise HTTPException(status_code=502, detail=f"OpenSearch error: {e.response.text}")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/impact")
+async def get_index_impact(
+    since_mz_timestamp: int = Query(..., description="mz_timestamp lower bound from write-triple"),
+) -> dict[str, Any]:
+    """Count orders documents re-indexed at or after a given mz_timestamp.
+
+    Returns the number of OpenSearch documents that carry an mz_timestamp
+    >= since_mz_timestamp, the total document count, and the percentage.
+    Use the mz_timestamp_lower_bound from the write-triple response as the
+    lower bound to measure how many docs were re-indexed as a result of a write.
+    """
+    try:
+        async with httpx.AsyncClient(timeout=OPENSEARCH_TIMEOUT) as client:
+            total_resp = await client.get(f"{settings.os_url}/orders/_count")
+            if total_resp.status_code == 404:
+                return {"impacted": 0, "total": 0, "pct": 0.0}
+            total_resp.raise_for_status()
+            total = total_resp.json().get("count", 0)
+
+            impact_resp = await client.post(
+                f"{settings.os_url}/orders/_count",
+                json={"query": {"range": {"mz_timestamp": {"gte": since_mz_timestamp}}}},
+                headers={"Content-Type": "application/json"},
+            )
+            if impact_resp.status_code == 404:
+                return {"impacted": 0, "total": total, "pct": 0.0}
+            impact_resp.raise_for_status()
+            impacted = impact_resp.json().get("count", 0)
+
+            pct = round(impacted / total * 100, 1) if total > 0 else 0.0
+            return {"impacted": impacted, "total": total, "pct": pct}
+    except httpx.ConnectError as e:
+        logger.error(f"Failed to connect to OpenSearch: {e}", exc_info=True)
+        raise HTTPException(status_code=503, detail="OpenSearch is not available.")
+    except httpx.HTTPStatusError as e:
+        raise HTTPException(status_code=502, detail=f"OpenSearch error: {e.response.text}")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/api/src/routes/search.py
+++ b/api/src/routes/search.py
@@ -8,9 +8,11 @@ import logging
 from typing import Any
 
 import httpx
-from fastapi import APIRouter, Query, HTTPException
+from fastapi import APIRouter, Depends, Query, HTTPException
 
 from src.config import get_settings
+from src.freshmart.service import FreshMartService
+from src.routes.freshmart import get_freshmart_service
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +24,37 @@ settings = get_settings()
 DEFAULT_SEARCH_LIMIT = 5
 MAX_SEARCH_LIMIT = 20
 OPENSEARCH_TIMEOUT = 10.0
+
+
+# Module-level lazy-init embedder singleton. The fastembed model is heavyweight,
+# so we only construct it on first use and reuse it across requests.
+_query_embedder = None
+
+
+def get_query_embedder():
+    """Return a lazy-initialized fastembed text embedder.
+
+    Returns an object with an `embed(texts: list[str]) -> list[list[float]]`
+    method producing 384-dim vectors using BAAI/bge-small-en-v1.5.
+    """
+    global _query_embedder
+    if _query_embedder is None:
+        try:
+            from fastembed import TextEmbedding
+
+            class _Embedder:
+                def __init__(self):
+                    self._model = TextEmbedding(model_name="BAAI/bge-small-en-v1.5")
+
+                def embed(self, texts):
+                    return [list(v) for v in self._model.embed(texts)]
+
+            _query_embedder = _Embedder()
+        except ImportError as e:
+            raise RuntimeError(
+                "fastembed not installed - run: pip install fastembed"
+            ) from e
+    return _query_embedder
 
 
 @router.get("/orders")
@@ -99,3 +132,129 @@ async def search_orders(
             status_code=500,
             detail=f"Search failed: {str(e)}",
         )
+
+
+@router.get("/vector/orders")
+async def vector_search_orders(
+    q: str = Query(..., min_length=1, description="Natural language search query"),
+    limit: int = Query(default=DEFAULT_SEARCH_LIMIT, ge=1, le=MAX_SEARCH_LIMIT),
+    service: FreshMartService = Depends(get_freshmart_service),
+) -> dict[str, Any]:
+    """
+    Vector (kNN) search across orders, hydrated with live data from Materialize.
+
+    Pipeline:
+        1. Embed the query text with fastembed (BAAI/bge-small-en-v1.5, 384-dim).
+        2. Run an OpenSearch knn search against the `orders` index — this
+           answers "which orders are semantically relevant?".
+        3. For each hit, look up the *current* order state in Materialize
+           (orders_with_lines_mv) — this answers "what does the order
+           contain right now?".
+        4. Merge the OS scoring metadata with the live Materialize fields
+           and return a unified result list.
+
+    Orders that no longer exist in Materialize (e.g. deleted) are dropped.
+    """
+    # 1. Embed query
+    embedder = get_query_embedder()
+    vector = embedder.embed([q])[0]
+
+    # 2. Build OpenSearch knn body
+    search_body = {
+        "query": {
+            "knn": {
+                "embedding": {
+                    "vector": list(vector),
+                    "k": limit,
+                }
+            }
+        },
+        "_source": ["order_id", "embedding_text", "embedded_at"],
+        "size": limit,
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=OPENSEARCH_TIMEOUT) as client:
+            response = await client.post(
+                f"{settings.os_url}/orders/_search",
+                json=search_body,
+                headers={"Content-Type": "application/json"},
+            )
+
+            if response.status_code == 404:
+                logger.info(
+                    "OpenSearch index 'orders' does not exist yet, returning empty vector results"
+                )
+                return {"results": [], "query": q, "total": 0}
+
+            response.raise_for_status()
+            os_result = response.json()
+
+    except httpx.ConnectError as e:
+        logger.error(f"Failed to connect to OpenSearch: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=503,
+            detail="OpenSearch is not available. Ensure the search-sync service is running.",
+        )
+    except httpx.HTTPStatusError as e:
+        logger.error(
+            f"OpenSearch returned error status {e.response.status_code}: {e.response.text}",
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=502,
+            detail=f"OpenSearch error: {e.response.text}",
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Unexpected error during vector search: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail=f"Vector search failed: {str(e)}",
+        )
+
+    # 3 + 4. Hydrate each hit from Materialize and merge
+    hits = os_result.get("hits", {}).get("hits", []) or []
+    results: list[dict[str, Any]] = []
+
+    for hit in hits:
+        source = hit.get("_source", {}) or {}
+        order_id = source.get("order_id") or hit.get("_id")
+        if not order_id:
+            continue
+
+        # Live hydration via Materialize
+        try:
+            order = await service.get_order(order_id)
+        except Exception as e:
+            logger.warning(
+                f"Failed to hydrate order {order_id} from Materialize: {e}",
+                exc_info=True,
+            )
+            continue
+
+        if order is None:
+            # Order was deleted between indexing and now - skip
+            logger.debug(f"Skipping {order_id}: not found in Materialize")
+            continue
+
+        merged: dict[str, Any] = {
+            "order_id": order_id,
+            "score": hit.get("_score"),
+            "embedding_text": source.get("embedding_text"),
+            "embedded_at": source.get("embedded_at"),
+        }
+        # Merge live fields (Pydantic v2). Live values win over OS source on
+        # conflicts because Materialize represents the current truth.
+        live = order.model_dump(mode="json")
+        merged.update(live)
+        # Re-pin the score / OS-only fields so they aren't clobbered if the
+        # OrderFlat ever grows fields with the same names.
+        merged["order_id"] = order_id
+        merged["score"] = hit.get("_score")
+        merged["embedding_text"] = source.get("embedding_text")
+        merged["embedded_at"] = source.get("embedded_at")
+        results.append(merged)
+
+    return {"results": results, "query": q, "total": len(results)}

--- a/api/src/routes/search.py
+++ b/api/src/routes/search.py
@@ -5,7 +5,7 @@ to perform semantic searches across denormalized order documents.
 """
 
 import logging
-from typing import Any
+from typing import Any, Optional
 
 import httpx
 from fastapi import APIRouter, Depends, Query, HTTPException
@@ -138,6 +138,8 @@ async def search_orders(
 async def vector_search_orders(
     q: str = Query(..., min_length=1, description="Natural language search query"),
     limit: int = Query(default=DEFAULT_SEARCH_LIMIT, ge=1, le=MAX_SEARCH_LIMIT),
+    store_zone: Optional[str] = Query(default=None),
+    order_status: Optional[str] = Query(default=None),
     service: FreshMartService = Depends(get_freshmart_service),
 ) -> dict[str, Any]:
     """
@@ -160,18 +162,36 @@ async def vector_search_orders(
     vector = embedder.embed([q])[0]
 
     # 2. Build OpenSearch knn body
-    search_body = {
-        "query": {
-            "knn": {
-                "embedding": {
-                    "vector": list(vector),
-                    "k": limit,
+    filters = []
+    if store_zone:
+        filters.append({"term": {"store_zone": store_zone}})
+    if order_status:
+        filters.append({"term": {"order_status": order_status}})
+
+    if filters:
+        search_body = {
+            "query": {
+                "bool": {
+                    "must": {"knn": {"embedding": {"vector": list(vector), "k": limit}}},
+                    "filter": filters,
                 }
-            }
-        },
-        "_source": ["order_id", "embedding", "embedding_text", "embedded_at", "line_items"],
-        "size": limit,
-    }
+            },
+            "_source": ["order_id", "embedding", "embedding_text", "embedded_at", "line_items"],
+            "size": limit,
+        }
+    else:
+        search_body = {
+            "query": {
+                "knn": {
+                    "embedding": {
+                        "vector": list(vector),
+                        "k": limit,
+                    }
+                }
+            },
+            "_source": ["order_id", "embedding", "embedding_text", "embedded_at", "line_items"],
+            "size": limit,
+        }
 
     try:
         async with httpx.AsyncClient(timeout=OPENSEARCH_TIMEOUT) as client:

--- a/api/src/routes/search.py
+++ b/api/src/routes/search.py
@@ -288,37 +288,50 @@ async def get_index_stats() -> dict[str, Any]:
         raise HTTPException(status_code=500, detail=str(e))
 
 
+IMPACT_INDEXES = ["orders", "inventory"]
+
+
 @router.get("/impact")
 async def get_index_impact(
     since_mz_timestamp: int = Query(..., description="mz_timestamp lower bound from write-triple"),
 ) -> dict[str, Any]:
-    """Count orders documents re-indexed at or after a given mz_timestamp.
+    """Count documents re-indexed across all indexes at or after a given mz_timestamp.
 
-    Returns the number of OpenSearch documents that carry an mz_timestamp
-    >= since_mz_timestamp, the total document count, and the percentage.
-    Use the mz_timestamp_lower_bound from the write-triple response as the
-    lower bound to measure how many docs were re-indexed as a result of a write.
+    Queries both the orders and inventory indexes. Returns combined impacted/total
+    counts plus a per-index breakdown.
     """
+    range_query = {"query": {"range": {"mz_timestamp": {"gte": since_mz_timestamp}}}}
     try:
         async with httpx.AsyncClient(timeout=OPENSEARCH_TIMEOUT) as client:
-            total_resp = await client.get(f"{settings.os_url}/orders/_count")
-            if total_resp.status_code == 404:
-                return {"impacted": 0, "total": 0, "pct": 0.0}
-            total_resp.raise_for_status()
-            total = total_resp.json().get("count", 0)
+            total = 0
+            impacted = 0
+            breakdown: dict[str, dict] = {}
 
-            impact_resp = await client.post(
-                f"{settings.os_url}/orders/_count",
-                json={"query": {"range": {"mz_timestamp": {"gte": since_mz_timestamp}}}},
-                headers={"Content-Type": "application/json"},
-            )
-            if impact_resp.status_code == 404:
-                return {"impacted": 0, "total": total, "pct": 0.0}
-            impact_resp.raise_for_status()
-            impacted = impact_resp.json().get("count", 0)
+            for index in IMPACT_INDEXES:
+                total_resp = await client.get(f"{settings.os_url}/{index}/_count")
+                if total_resp.status_code == 404:
+                    breakdown[index] = {"impacted": 0, "total": 0}
+                    continue
+                total_resp.raise_for_status()
+                idx_total = total_resp.json().get("count", 0)
+
+                impact_resp = await client.post(
+                    f"{settings.os_url}/{index}/_count",
+                    json=range_query,
+                    headers={"Content-Type": "application/json"},
+                )
+                if impact_resp.status_code == 404:
+                    idx_impacted = 0
+                else:
+                    impact_resp.raise_for_status()
+                    idx_impacted = impact_resp.json().get("count", 0)
+
+                breakdown[index] = {"impacted": idx_impacted, "total": idx_total}
+                total += idx_total
+                impacted += idx_impacted
 
             pct = round(impacted / total * 100, 1) if total > 0 else 0.0
-            return {"impacted": impacted, "total": total, "pct": pct}
+            return {"impacted": impacted, "total": total, "pct": pct, "breakdown": breakdown}
     except httpx.ConnectError as e:
         logger.error(f"Failed to connect to OpenSearch: {e}", exc_info=True)
         raise HTTPException(status_code=503, detail="OpenSearch is not available.")

--- a/api/src/routes/search.py
+++ b/api/src/routes/search.py
@@ -169,7 +169,7 @@ async def vector_search_orders(
                 }
             }
         },
-        "_source": ["order_id", "embedding_text", "embedded_at"],
+        "_source": ["order_id", "embedding_text", "embedded_at", "line_items"],
         "size": limit,
     }
 
@@ -239,22 +239,29 @@ async def vector_search_orders(
             logger.debug(f"Skipping {order_id}: not found in Materialize")
             continue
 
+        # model_dump(mode="json") serializes Decimal as str; convert to float.
+        live = order.model_dump(mode="json")
+        if live.get("order_total_amount") is not None:
+            live["order_total_amount"] = float(live["order_total_amount"])
+
         merged: dict[str, Any] = {
             "order_id": order_id,
             "score": hit.get("_score"),
             "embedding_text": source.get("embedding_text"),
             "embedded_at": source.get("embedded_at"),
+            # Line items come from OpenSearch (indexed from Materialize CDC,
+            # <2s latency). They carry live_price, base_price, etc. because
+            # search-sync joins inventory_items_with_dynamic_pricing_mv.
+            "line_items": source.get("line_items") or [],
         }
-        # Merge live fields (Pydantic v2). Live values win over OS source on
-        # conflicts because Materialize represents the current truth.
-        live = order.model_dump(mode="json")
+        # Merge live Materialize fields — live values win on conflicts.
         merged.update(live)
-        # Re-pin the score / OS-only fields so they aren't clobbered if the
-        # OrderFlat ever grows fields with the same names.
+        # Re-pin OS-only fields so they aren't clobbered by OrderFlat.
         merged["order_id"] = order_id
         merged["score"] = hit.get("_score")
         merged["embedding_text"] = source.get("embedding_text")
         merged["embedded_at"] = source.get("embedded_at")
+        merged["line_items"] = source.get("line_items") or []
         results.append(merged)
 
     return {"results": results, "query": q, "total": len(results)}

--- a/api/tests/test_query_stats.py
+++ b/api/tests/test_query_stats.py
@@ -286,40 +286,11 @@ class TestQueryStatsAPI:
 
 
 class TestWriteTripleMzTimestamp:
-    """write_triple returns mz_timestamp_lower_bound from a pre-write Materialize read."""
+    """write_triple returns a wall-clock mz_timestamp_lower_bound before the PG write."""
 
     @pytest.mark.asyncio
-    async def test_returns_mz_lower_bound(self, async_client: AsyncClient):
-        from unittest.mock import AsyncMock, MagicMock, patch
-
-        mz_result = MagicMock()
-        mz_result.fetchone.return_value = ("1746198234001",)
-        mz_session = AsyncMock()
-        mz_session.execute = AsyncMock(return_value=mz_result)
-        mz_session.__aenter__ = AsyncMock(return_value=mz_session)
-        mz_session.__aexit__ = AsyncMock(return_value=False)
-
-        pg_result = MagicMock()
-        pg_result.fetchone.return_value = (1,)
-        pg_session = AsyncMock()
-        pg_session.execute = AsyncMock(return_value=pg_result)
-        pg_session.commit = AsyncMock()
-        pg_session.__aenter__ = AsyncMock(return_value=pg_session)
-        pg_session.__aexit__ = AsyncMock(return_value=False)
-
-        with patch("src.routes.query_stats.get_mz_session", return_value=mz_session), \
-             patch("src.routes.query_stats.get_pg_session", return_value=pg_session):
-            response = await async_client.post(
-                "/api/query-stats/write-triple",
-                json={"subject_id": "order:FM-001", "predicate": "order_status", "object_value": "DELIVERED"},
-            )
-        assert response.status_code == 200
-        data = response.json()
-        assert data["status"] == "written"
-        assert data["mz_timestamp_lower_bound"] == 1746198234001
-
-    @pytest.mark.asyncio
-    async def test_null_lower_bound_when_mz_unavailable(self, async_client: AsyncClient):
+    async def test_returns_wall_clock_lower_bound(self, async_client: AsyncClient):
+        import time
         from unittest.mock import AsyncMock, MagicMock, patch
 
         pg_result = MagicMock()
@@ -330,13 +301,43 @@ class TestWriteTripleMzTimestamp:
         pg_session.__aenter__ = AsyncMock(return_value=pg_session)
         pg_session.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("src.routes.query_stats.get_mz_session", side_effect=Exception("unavailable")), \
-             patch("src.routes.query_stats.get_pg_session", return_value=pg_session):
+        before_ms = int(time.time() * 1000)
+        with patch("src.routes.query_stats.get_pg_session", return_value=pg_session):
+            response = await async_client.post(
+                "/api/query-stats/write-triple",
+                json={"subject_id": "order:FM-001", "predicate": "order_status", "object_value": "DELIVERED"},
+            )
+        after_ms = int(time.time() * 1000)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "written"
+        lb = data["mz_timestamp_lower_bound"]
+        assert lb is not None
+        assert isinstance(lb, int)
+        # Lower bound must fall within the request window
+        assert before_ms <= lb <= after_ms
+
+    @pytest.mark.asyncio
+    async def test_lower_bound_always_set(self, async_client: AsyncClient):
+        """Lower bound is always a wall-clock int — no Materialize dependency."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        pg_result = MagicMock()
+        pg_result.fetchone.return_value = (1,)
+        pg_session = AsyncMock()
+        pg_session.execute = AsyncMock(return_value=pg_result)
+        pg_session.commit = AsyncMock()
+        pg_session.__aenter__ = AsyncMock(return_value=pg_session)
+        pg_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("src.routes.query_stats.get_pg_session", return_value=pg_session):
             response = await async_client.post(
                 "/api/query-stats/write-triple",
                 json={"subject_id": "order:FM-001", "predicate": "order_status", "object_value": "DELIVERED"},
             )
         assert response.status_code == 200
         data = response.json()
-        assert data["status"] == "written"
-        assert data["mz_timestamp_lower_bound"] is None
+        assert data["mz_timestamp_lower_bound"] is not None
+        # Sanity: epoch ms for dates after 2020-01-01
+        assert data["mz_timestamp_lower_bound"] > 1_577_836_800_000

--- a/api/tests/test_query_stats.py
+++ b/api/tests/test_query_stats.py
@@ -283,3 +283,60 @@ class TestQueryStatsAPI:
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "stopped"
+
+
+class TestWriteTripleMzTimestamp:
+    """write_triple returns mz_timestamp_lower_bound from a pre-write Materialize read."""
+
+    @pytest.mark.asyncio
+    async def test_returns_mz_lower_bound(self, async_client: AsyncClient):
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        mz_result = MagicMock()
+        mz_result.fetchone.return_value = ("1746198234001",)
+        mz_session = AsyncMock()
+        mz_session.execute = AsyncMock(return_value=mz_result)
+        mz_session.__aenter__ = AsyncMock(return_value=mz_session)
+        mz_session.__aexit__ = AsyncMock(return_value=False)
+
+        pg_result = MagicMock()
+        pg_result.fetchone.return_value = (1,)
+        pg_session = AsyncMock()
+        pg_session.execute = AsyncMock(return_value=pg_result)
+        pg_session.commit = AsyncMock()
+        pg_session.__aenter__ = AsyncMock(return_value=pg_session)
+        pg_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("src.routes.query_stats.get_mz_session", return_value=mz_session), \
+             patch("src.routes.query_stats.get_pg_session", return_value=pg_session):
+            response = await async_client.post(
+                "/api/query-stats/write-triple",
+                json={"subject_id": "order:FM-001", "predicate": "order_status", "object_value": "DELIVERED"},
+            )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "written"
+        assert data["mz_timestamp_lower_bound"] == 1746198234001
+
+    @pytest.mark.asyncio
+    async def test_null_lower_bound_when_mz_unavailable(self, async_client: AsyncClient):
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        pg_result = MagicMock()
+        pg_result.fetchone.return_value = (1,)
+        pg_session = AsyncMock()
+        pg_session.execute = AsyncMock(return_value=pg_result)
+        pg_session.commit = AsyncMock()
+        pg_session.__aenter__ = AsyncMock(return_value=pg_session)
+        pg_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("src.routes.query_stats.get_mz_session", side_effect=Exception("unavailable")), \
+             patch("src.routes.query_stats.get_pg_session", return_value=pg_session):
+            response = await async_client.post(
+                "/api/query-stats/write-triple",
+                json={"subject_id": "order:FM-001", "predicate": "order_status", "object_value": "DELIVERED"},
+            )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "written"
+        assert data["mz_timestamp_lower_bound"] is None

--- a/api/tests/test_search_api.py
+++ b/api/tests/test_search_api.py
@@ -554,3 +554,113 @@ class TestVectorSearchOrdersAPI:
         # The deleted one must not be present
         for item in data["results"]:
             assert item["order_id"] != "order:FM-DELETED"
+
+
+# ---------------------------------------------------------------------------
+# Helpers for mocking httpx.AsyncClient inside routes without affecting the
+# ASGI test client (which also uses httpx under the hood).
+# ---------------------------------------------------------------------------
+
+def _make_mock_httpx_client(
+    get_response=None, post_response=None,
+    get_side_effect=None, post_side_effect=None,
+):
+    inner = MagicMock()
+    inner.get = AsyncMock(side_effect=get_side_effect) if get_side_effect else AsyncMock(return_value=get_response)
+    inner.post = AsyncMock(side_effect=post_side_effect) if post_side_effect else AsyncMock(return_value=post_response)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=inner)
+    cm.__aexit__ = AsyncMock(return_value=None)
+    return MagicMock(return_value=cm), inner
+
+
+class TestIndexStatsAPI:
+    """Tests for GET /api/search/index-stats."""
+
+    @pytest.mark.asyncio
+    async def test_returns_doc_count(self, async_client: AsyncClient):
+        resp = AsyncMock(status_code=200, json=lambda: {"count": 1203})
+        resp.raise_for_status = lambda: None
+        factory, _ = _make_mock_httpx_client(get_response=resp)
+        with patch("src.routes.search.httpx.AsyncClient", factory):
+            response = await async_client.get("/api/search/index-stats")
+        assert response.status_code == 200
+        assert response.json() == {"doc_count": 1203}
+
+    @pytest.mark.asyncio
+    async def test_index_not_found_returns_zero(self, async_client: AsyncClient):
+        resp = AsyncMock(status_code=404)
+        factory, _ = _make_mock_httpx_client(get_response=resp)
+        with patch("src.routes.search.httpx.AsyncClient", factory):
+            response = await async_client.get("/api/search/index-stats")
+        assert response.status_code == 200
+        assert response.json() == {"doc_count": 0}
+
+    @pytest.mark.asyncio
+    async def test_opensearch_unavailable_returns_503(self, async_client: AsyncClient):
+        import httpx
+        factory, _ = _make_mock_httpx_client(get_side_effect=httpx.ConnectError("refused"))
+        with patch("src.routes.search.httpx.AsyncClient", factory):
+            response = await async_client.get("/api/search/index-stats")
+        assert response.status_code == 503
+
+
+class TestIndexImpactAPI:
+    """Tests for GET /api/search/impact."""
+
+    @pytest.mark.asyncio
+    async def test_returns_impacted_total_and_pct(self, async_client: AsyncClient):
+        total_resp = AsyncMock(status_code=200, json=lambda: {"count": 1000})
+        total_resp.raise_for_status = lambda: None
+        impact_resp = AsyncMock(status_code=200, json=lambda: {"count": 47})
+        impact_resp.raise_for_status = lambda: None
+        factory, _ = _make_mock_httpx_client(get_response=total_resp, post_response=impact_resp)
+        with patch("src.routes.search.httpx.AsyncClient", factory):
+            response = await async_client.get(
+                "/api/search/impact", params={"since_mz_timestamp": 1746000000000}
+            )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1000
+        assert data["impacted"] == 47
+        assert data["pct"] == 4.7
+
+    @pytest.mark.asyncio
+    async def test_missing_param_returns_422(self, async_client: AsyncClient):
+        response = await async_client.get("/api/search/impact")
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_index_not_found_returns_zeros(self, async_client: AsyncClient):
+        resp = AsyncMock(status_code=404)
+        factory, _ = _make_mock_httpx_client(get_response=resp)
+        with patch("src.routes.search.httpx.AsyncClient", factory):
+            response = await async_client.get(
+                "/api/search/impact", params={"since_mz_timestamp": 1746000000000}
+            )
+        assert response.status_code == 200
+        assert response.json() == {"impacted": 0, "total": 0, "pct": 0.0}
+
+    @pytest.mark.asyncio
+    async def test_opensearch_unavailable_returns_503(self, async_client: AsyncClient):
+        import httpx
+        factory, _ = _make_mock_httpx_client(get_side_effect=httpx.ConnectError("refused"))
+        with patch("src.routes.search.httpx.AsyncClient", factory):
+            response = await async_client.get(
+                "/api/search/impact", params={"since_mz_timestamp": 1746000000000}
+            )
+        assert response.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_zero_total_returns_zero_pct(self, async_client: AsyncClient):
+        total_resp = AsyncMock(status_code=200, json=lambda: {"count": 0})
+        total_resp.raise_for_status = lambda: None
+        impact_resp = AsyncMock(status_code=200, json=lambda: {"count": 0})
+        impact_resp.raise_for_status = lambda: None
+        factory, _ = _make_mock_httpx_client(get_response=total_resp, post_response=impact_resp)
+        with patch("src.routes.search.httpx.AsyncClient", factory):
+            response = await async_client.get(
+                "/api/search/impact", params={"since_mz_timestamp": 1746000000000}
+            )
+        assert response.status_code == 200
+        assert response.json()["pct"] == 0.0

--- a/api/tests/test_search_api.py
+++ b/api/tests/test_search_api.py
@@ -610,6 +610,8 @@ class TestIndexImpactAPI:
 
     @pytest.mark.asyncio
     async def test_returns_impacted_total_and_pct(self, async_client: AsyncClient):
+        # IMPACT_INDEXES has 2 entries; each returns count=1000 (total) / count=47 (impacted).
+        # The endpoint sums across all indexes: total=2000, impacted=94, pct=4.7.
         total_resp = AsyncMock(status_code=200, json=lambda: {"count": 1000})
         total_resp.raise_for_status = lambda: None
         impact_resp = AsyncMock(status_code=200, json=lambda: {"count": 47})
@@ -621,8 +623,8 @@ class TestIndexImpactAPI:
             )
         assert response.status_code == 200
         data = response.json()
-        assert data["total"] == 1000
-        assert data["impacted"] == 47
+        assert data["total"] == 2000
+        assert data["impacted"] == 94
         assert data["pct"] == 4.7
 
     @pytest.mark.asyncio
@@ -639,7 +641,10 @@ class TestIndexImpactAPI:
                 "/api/search/impact", params={"since_mz_timestamp": 1746000000000}
             )
         assert response.status_code == 200
-        assert response.json() == {"impacted": 0, "total": 0, "pct": 0.0}
+        data = response.json()
+        assert data["impacted"] == 0
+        assert data["total"] == 0
+        assert data["pct"] == 0.0
 
     @pytest.mark.asyncio
     async def test_opensearch_unavailable_returns_503(self, async_client: AsyncClient):

--- a/api/tests/test_search_api.py
+++ b/api/tests/test_search_api.py
@@ -1,8 +1,11 @@
 """Integration tests for Search API endpoints."""
 
+from datetime import datetime, timezone
+from typing import Optional
+
 import pytest
 from httpx import AsyncClient
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from tests.conftest import requires_db
 
@@ -210,3 +213,344 @@ class TestSearchOrdersAPI:
             assert call_args is not None
             request_body = call_args.kwargs["json"]
             assert request_body["size"] == 5
+
+
+# =============================================================================
+# Vector Search Tests
+# =============================================================================
+
+
+def _make_mock_order(order_id: str = "order:FM-1001"):
+    """Build a representative OrderFlat for mocking Materialize hydration."""
+    from src.freshmart.models import OrderFlat
+
+    return OrderFlat(
+        order_id=order_id,
+        order_number="FM-1001",
+        order_status="OUT_FOR_DELIVERY",
+        store_id="store:BK-01",
+        customer_id="customer:101",
+        customer_name="Alex Thompson",
+        customer_email="alex@example.com",
+        customer_address="123 Main St",
+        store_name="FreshMart Brooklyn",
+        store_zone="Brooklyn",
+        store_address="100 Court St",
+        order_total_amount=45.99,
+        delivery_window_start=None,
+        delivery_window_end=None,
+        assigned_courier_id=None,
+        delivery_task_status=None,
+        delivery_eta=None,
+        effective_updated_at=datetime(2024, 1, 15, tzinfo=timezone.utc),
+    )
+
+
+def _make_knn_response(
+    order_ids: Optional[list] = None,
+    embedding_text: str = "Order containing organic produce for Alex",
+) -> dict:
+    """Build a representative OpenSearch knn response."""
+    if order_ids is None:
+        order_ids = ["order:FM-1001"]
+    hits = []
+    for i, oid in enumerate(order_ids):
+        hits.append(
+            {
+                "_index": "orders",
+                "_id": oid,
+                "_score": 0.95 - (i * 0.05),
+                "_source": {
+                    "order_id": oid,
+                    "embedding_text": embedding_text,
+                    "embedded_at": "2024-01-15T12:00:00Z",
+                },
+            }
+        )
+    return {
+        "took": 4,
+        "timed_out": False,
+        "_shards": {"total": 1, "successful": 1, "skipped": 0, "failed": 0},
+        "hits": {
+            "total": {"value": len(hits), "relation": "eq"},
+            "max_score": hits[0]["_score"] if hits else None,
+            "hits": hits,
+        },
+    }
+
+
+class TestVectorSearchOrdersAPI:
+    """Tests for /api/search/vector/orders endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_vector_search_valid_query(self, async_client: AsyncClient):
+        """GET /api/search/vector/orders with valid query returns merged results."""
+        from src.main import app
+        from src.routes.freshmart import get_freshmart_service
+
+        os_response = _make_knn_response(["order:FM-1001"])
+        mock_order = _make_mock_order("order:FM-1001")
+
+        async def mock_service():
+            svc = AsyncMock()
+            svc.get_order = AsyncMock(return_value=mock_order)
+            return svc
+
+        with patch("src.routes.search.get_query_embedder") as mock_get_embedder, \
+                patch("httpx.AsyncClient.post") as mock_post:
+            mock_embedder = MagicMock()
+            mock_embedder.embed.return_value = [[0.1] * 384]
+            mock_get_embedder.return_value = mock_embedder
+
+            mock_post.return_value = AsyncMock(
+                status_code=200,
+                json=lambda: os_response,
+            )
+            mock_post.return_value.raise_for_status = lambda: None
+
+            app.dependency_overrides[get_freshmart_service] = mock_service
+            try:
+                response = await async_client.get(
+                    "/api/search/vector/orders", params={"q": "organic produce"}
+                )
+            finally:
+                app.dependency_overrides.clear()
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "results" in data
+        assert isinstance(data["results"], list)
+        assert len(data["results"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_vector_search_empty_query_rejected(self, async_client: AsyncClient):
+        """GET /api/search/vector/orders without `q` param returns 422."""
+        from src.main import app
+        from src.routes.freshmart import get_freshmart_service
+
+        async def mock_service():
+            return AsyncMock()
+
+        app.dependency_overrides[get_freshmart_service] = mock_service
+        try:
+            response = await async_client.get("/api/search/vector/orders")
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_vector_search_query_too_short(self, async_client: AsyncClient):
+        """GET /api/search/vector/orders with empty `q` returns 422."""
+        from src.main import app
+        from src.routes.freshmart import get_freshmart_service
+
+        async def mock_service():
+            return AsyncMock()
+
+        app.dependency_overrides[get_freshmart_service] = mock_service
+        try:
+            response = await async_client.get(
+                "/api/search/vector/orders", params={"q": ""}
+            )
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_vector_search_opensearch_unavailable(self, async_client: AsyncClient):
+        """GET /api/search/vector/orders returns 503 when OpenSearch is down."""
+        import httpx
+
+        from src.main import app
+        from src.routes.freshmart import get_freshmart_service
+
+        async def mock_service():
+            return AsyncMock()
+
+        with patch("src.routes.search.get_query_embedder") as mock_get_embedder, \
+                patch("httpx.AsyncClient.post") as mock_post:
+            mock_embedder = MagicMock()
+            mock_embedder.embed.return_value = [[0.1] * 384]
+            mock_get_embedder.return_value = mock_embedder
+
+            mock_post.side_effect = httpx.ConnectError("Connection refused")
+
+            app.dependency_overrides[get_freshmart_service] = mock_service
+            try:
+                response = await async_client.get(
+                    "/api/search/vector/orders", params={"q": "anything"}
+                )
+            finally:
+                app.dependency_overrides.clear()
+
+        assert response.status_code == 503
+        assert "not available" in response.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_vector_search_index_not_found(self, async_client: AsyncClient):
+        """GET /api/search/vector/orders returns 200 with empty results when OS 404s."""
+        from src.main import app
+        from src.routes.freshmart import get_freshmart_service
+
+        async def mock_service():
+            return AsyncMock()
+
+        with patch("src.routes.search.get_query_embedder") as mock_get_embedder, \
+                patch("httpx.AsyncClient.post") as mock_post:
+            mock_embedder = MagicMock()
+            mock_embedder.embed.return_value = [[0.1] * 384]
+            mock_get_embedder.return_value = mock_embedder
+
+            mock_post.return_value = AsyncMock(status_code=404)
+
+            app.dependency_overrides[get_freshmart_service] = mock_service
+            try:
+                response = await async_client.get(
+                    "/api/search/vector/orders", params={"q": "anything"}
+                )
+            finally:
+                app.dependency_overrides.clear()
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "results" in data
+        assert data["results"] == []
+
+    @pytest.mark.asyncio
+    async def test_vector_search_response_shape(self, async_client: AsyncClient):
+        """Each result item has order_id, score, embedding_text, embedded_at."""
+        from src.main import app
+        from src.routes.freshmart import get_freshmart_service
+
+        os_response = _make_knn_response(["order:FM-1001"])
+        mock_order = _make_mock_order("order:FM-1001")
+
+        async def mock_service():
+            svc = AsyncMock()
+            svc.get_order = AsyncMock(return_value=mock_order)
+            return svc
+
+        with patch("src.routes.search.get_query_embedder") as mock_get_embedder, \
+                patch("httpx.AsyncClient.post") as mock_post:
+            mock_embedder = MagicMock()
+            mock_embedder.embed.return_value = [[0.1] * 384]
+            mock_get_embedder.return_value = mock_embedder
+
+            mock_post.return_value = AsyncMock(
+                status_code=200,
+                json=lambda: os_response,
+            )
+            mock_post.return_value.raise_for_status = lambda: None
+
+            app.dependency_overrides[get_freshmart_service] = mock_service
+            try:
+                response = await async_client.get(
+                    "/api/search/vector/orders", params={"q": "produce"}
+                )
+            finally:
+                app.dependency_overrides.clear()
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "results" in data
+        assert isinstance(data["results"], list)
+        assert len(data["results"]) >= 1
+
+        item = data["results"][0]
+        assert "order_id" in item
+        assert "score" in item
+        assert "embedding_text" in item
+        assert "embedded_at" in item
+
+    @pytest.mark.asyncio
+    async def test_vector_search_merges_live_data(self, async_client: AsyncClient):
+        """Live fields from Materialize are merged into each result item."""
+        from src.main import app
+        from src.routes.freshmart import get_freshmart_service
+
+        # OS hit only has the minimal source fields (no order_status/customer_name)
+        os_response = _make_knn_response(["order:FM-1001"])
+        mock_order = _make_mock_order("order:FM-1001")
+
+        async def mock_service():
+            svc = AsyncMock()
+            svc.get_order = AsyncMock(return_value=mock_order)
+            return svc
+
+        with patch("src.routes.search.get_query_embedder") as mock_get_embedder, \
+                patch("httpx.AsyncClient.post") as mock_post:
+            mock_embedder = MagicMock()
+            mock_embedder.embed.return_value = [[0.1] * 384]
+            mock_get_embedder.return_value = mock_embedder
+
+            mock_post.return_value = AsyncMock(
+                status_code=200,
+                json=lambda: os_response,
+            )
+            mock_post.return_value.raise_for_status = lambda: None
+
+            app.dependency_overrides[get_freshmart_service] = mock_service
+            try:
+                response = await async_client.get(
+                    "/api/search/vector/orders", params={"q": "produce"}
+                )
+            finally:
+                app.dependency_overrides.clear()
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["results"]) == 1
+        item = data["results"][0]
+        # Live fields from Materialize must be present
+        assert item.get("order_status") == "OUT_FOR_DELIVERY"
+        assert item.get("customer_name") == "Alex Thompson"
+        assert item.get("store_name") == "FreshMart Brooklyn"
+
+    @pytest.mark.asyncio
+    async def test_vector_search_handles_no_mz_match(self, async_client: AsyncClient):
+        """If Materialize returns None for an order_id, that result is omitted."""
+        from src.main import app
+        from src.routes.freshmart import get_freshmart_service
+
+        # Two hits: one will resolve, the other will not
+        os_response = _make_knn_response(["order:FM-1001", "order:FM-DELETED"])
+        mock_order = _make_mock_order("order:FM-1001")
+
+        async def mock_service():
+            svc = AsyncMock()
+
+            async def get_order(oid: str):
+                if oid == "order:FM-1001":
+                    return mock_order
+                return None
+
+            svc.get_order = AsyncMock(side_effect=get_order)
+            return svc
+
+        with patch("src.routes.search.get_query_embedder") as mock_get_embedder, \
+                patch("httpx.AsyncClient.post") as mock_post:
+            mock_embedder = MagicMock()
+            mock_embedder.embed.return_value = [[0.1] * 384]
+            mock_get_embedder.return_value = mock_embedder
+
+            mock_post.return_value = AsyncMock(
+                status_code=200,
+                json=lambda: os_response,
+            )
+            mock_post.return_value.raise_for_status = lambda: None
+
+            app.dependency_overrides[get_freshmart_service] = mock_service
+            try:
+                response = await async_client.get(
+                    "/api/search/vector/orders", params={"q": "produce"}
+                )
+            finally:
+                app.dependency_overrides.clear()
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["results"]) == 1
+        assert data["results"][0]["order_id"] == "order:FM-1001"
+        # The deleted one must not be present
+        for item in data["results"]:
+            assert item["order_id"] != "order:FM-DELETED"

--- a/aws/deploy.sh
+++ b/aws/deploy.sh
@@ -113,19 +113,21 @@ fi
 SG_ID=$(load_state "security-group-id")
 MY_IP=$(curl -s --max-time 5 https://checkip.amazonaws.com | tr -d '[:space:]')
 
+update_sg_ingress() {
+  local sg="$1" ip="$2"
+  aws ec2 revoke-security-group-ingress --group-id "$sg" \
+    --protocol tcp --port 22 --cidr 0.0.0.0/0 2>/dev/null || true
+  aws ec2 revoke-security-group-ingress --group-id "$sg" \
+    --ip-permissions "$(aws ec2 describe-security-groups --group-ids "$sg" \
+      --query "SecurityGroups[0].IpPermissions" --output json 2>/dev/null)" 2>/dev/null || true
+  aws ec2 authorize-security-group-ingress --group-id "$sg" \
+    --protocol tcp --port 22 --cidr "${ip}/32" >/dev/null
+}
+
 if [[ -n "$SG_ID" ]]; then
-  # Validate the security group still exists
   if aws ec2 describe-security-groups --group-ids "$SG_ID" &>/dev/null; then
-    log "Using existing security group: $SG_ID"
-    # Update ingress to current IP
-    aws ec2 revoke-security-group-ingress --group-id "$SG_ID" \
-      --protocol tcp --port 22 --cidr 0.0.0.0/0 2>/dev/null || true
-    # Revoke any specific IP rules too
-    aws ec2 revoke-security-group-ingress --group-id "$SG_ID" \
-      --ip-permissions "$(aws ec2 describe-security-groups --group-ids "$SG_ID" \
-        --query "SecurityGroups[0].IpPermissions" --output json 2>/dev/null)" 2>/dev/null || true
-    aws ec2 authorize-security-group-ingress --group-id "$SG_ID" \
-      --protocol tcp --port 22 --cidr "${MY_IP}/32" >/dev/null
+    log "Using existing security group: $SG_ID (updating ingress to $MY_IP)"
+    update_sg_ingress "$SG_ID" "$MY_IP"
   else
     log "Stale security group ID, creating new one..."
     SG_ID=""
@@ -148,7 +150,8 @@ if [[ -z "$SG_ID" ]]; then
       --protocol tcp --port 22 --cidr "${MY_IP}/32" >/dev/null
     log "Created security group: $SG_ID (SSH from $MY_IP)"
   else
-    log "Recovered existing security group: $SG_ID"
+    log "Recovered existing security group: $SG_ID (updating ingress to $MY_IP)"
+    update_sg_ingress "$SG_ID" "$MY_IP"
   fi
   save_state "security-group-id" "$SG_ID"
 fi
@@ -230,6 +233,7 @@ for i in $(seq 1 30); do
     echo "Error: SSH connection timed out after 30 attempts"
     exit 1
   fi
+  log "SSH not ready yet, retrying in 5s... (attempt $i/30)"
   sleep 5
 done
 
@@ -242,6 +246,7 @@ for i in $(seq 1 60); do
     echo "Error: cloud-init did not complete within timeout"
     exit 1
   fi
+  log "cloud-init still running, retrying in 5s... (attempt $i/60)"
   sleep 5
 done
 
@@ -352,6 +357,7 @@ wait_for_hydration() {
       echo "  All $EXPECTED views hydrated after $((i*5))s"
       return 0
     fi
+    echo "  $hydrated/$EXPECTED views hydrated, retrying in 5s... ($((i*5))s elapsed)"
   done
   echo "  ERROR: only $hydrated/$EXPECTED views hydrated after 300s"
   docker compose exec -T mz psql -h localhost -p 6875 -U materialize -d materialize -c "SELECT mv.name, hs.hydrated FROM mz_internal.mz_hydration_statuses hs RIGHT JOIN mz_catalog.mz_materialized_views mv ON mv.id = hs.object_id WHERE mv.name IN ($QUOTED) ORDER BY mv.name;" || true

--- a/aws/teardown.sh
+++ b/aws/teardown.sh
@@ -59,6 +59,7 @@ if [[ -n "$SG_ID" ]]; then
       echo "Warning: Could not delete security group $SG_ID after 12 attempts"
       echo "         It may still have dependent ENIs. Delete manually in AWS Console."
     else
+      log "Security group still has dependent ENIs, retrying in 10s... (attempt $i/12)"
       sleep 10
     fi
   done

--- a/db/materialize/init.sh
+++ b/db/materialize/init.sh
@@ -719,7 +719,15 @@ FROM store_inventory_mv inv
 LEFT JOIN pricing_factors pf ON pf.product_id = inv.product_id
 WHERE inv.unit_price IS NOT NULL;"
 
-# Orders with aggregated line items and search fields (customer, store, delivery info)
+echo "Creating dynamic pricing materialized view and indexes..."
+
+# Materialize the dynamic pricing view
+psql -h "$MZ_HOST" -p "$MZ_PORT" -U materialize -c "
+CREATE MATERIALIZED VIEW IF NOT EXISTS inventory_items_with_dynamic_pricing_mv
+IN CLUSTER compute AS
+SELECT * FROM inventory_items_with_dynamic_pricing;"
+
+# Orders with aggregated line items, search fields, and live pricing (joins inventory MV above)
 psql -h "$MZ_HOST" -p "$MZ_PORT" -U materialize -c "
 CREATE MATERIALIZED VIEW IF NOT EXISTS orders_with_lines_mv IN CLUSTER compute AS
 SELECT
@@ -744,7 +752,7 @@ SELECT
     dt.assigned_courier_id,
     dt.task_status AS delivery_task_status,
     dt.eta AS delivery_eta,
-    -- Line items (static order data only - no dynamic pricing)
+    -- Line items with dynamic pricing from inventory
     COALESCE(
         jsonb_agg(
             jsonb_build_object(
@@ -757,7 +765,20 @@ SELECT
                 'line_amount', ol.line_amount,
                 'line_sequence', ol.line_sequence,
                 'perishable_flag', ol.perishable_flag,
-                'unit_weight_grams', ol.unit_weight_grams
+                'unit_weight_grams', ol.unit_weight_grams,
+                -- Dynamic pricing (null if no inventory record for this product+store)
+                'inventory_id', ip.inventory_id,
+                'base_price', ip.base_price,
+                'live_price', ip.live_price,
+                'price_change', ip.price_change,
+                'zone_adjustment', ip.zone_adjustment,
+                'perishable_adjustment', ip.perishable_adjustment,
+                'local_stock_adjustment', ip.local_stock_adjustment,
+                'popularity_adjustment', ip.popularity_adjustment,
+                'scarcity_adjustment', ip.scarcity_adjustment,
+                'demand_multiplier', ip.demand_multiplier,
+                'demand_premium', ip.demand_premium,
+                'current_stock', ip.available_quantity
             ) ORDER BY ol.line_sequence
         ) FILTER (WHERE ol.line_id IS NOT NULL),
         '[]'::jsonb
@@ -771,13 +792,16 @@ SELECT
         MAX(ol.effective_updated_at),
         c.effective_updated_at,
         s.effective_updated_at,
-        dt.effective_updated_at
+        dt.effective_updated_at,
+        MAX(ip.effective_updated_at)
     ) AS effective_updated_at
 FROM orders_flat_mv o
 LEFT JOIN customers_flat c ON c.customer_id = o.customer_id
 LEFT JOIN stores_flat s ON s.store_id = o.store_id
 LEFT JOIN delivery_tasks_flat dt ON dt.order_id = o.order_id
 LEFT JOIN order_lines_flat_mv ol ON ol.order_id = o.order_id
+LEFT JOIN inventory_items_with_dynamic_pricing_mv ip
+    ON ip.product_id = ol.product_id AND ip.store_id = o.store_id
 GROUP BY
     o.order_id,
     o.order_number,
@@ -801,14 +825,6 @@ GROUP BY
     dt.task_status,
     dt.eta,
     dt.effective_updated_at;"
-
-echo "Creating dynamic pricing materialized view and indexes..."
-
-# Materialize the dynamic pricing view
-psql -h "$MZ_HOST" -p "$MZ_PORT" -U materialize -c "
-CREATE MATERIALIZED VIEW IF NOT EXISTS inventory_items_with_dynamic_pricing_mv
-IN CLUSTER compute AS
-SELECT * FROM inventory_items_with_dynamic_pricing;"
 echo "Creating indexes IN CLUSTER serving on materialized views..."
 
 # Create indexes in serving cluster on materialized views

--- a/search-sync/Dockerfile
+++ b/search-sync/Dockerfile
@@ -11,6 +11,10 @@ RUN apt-get update && apt-get install -y \
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Pre-download the embedding model so it's baked into the image (no
+# network/cold-start cost on first request). ~130MB ONNX weights.
+RUN python -c "from fastembed import TextEmbedding; TextEmbedding(model_name='BAAI/bge-small-en-v1.5')"
+
 # Copy application code
 COPY . .
 

--- a/search-sync/requirements.txt
+++ b/search-sync/requirements.txt
@@ -13,3 +13,6 @@ structlog==24.1.0
 
 # Async
 aiohttp==3.9.3
+
+# Local CPU vector embeddings (BAAI/bge-small-en-v1.5, 384-dim, ONNX)
+fastembed>=0.3.6

--- a/search-sync/src/base_subscribe_worker.py
+++ b/search-sync/src/base_subscribe_worker.py
@@ -861,6 +861,9 @@ class BaseSubscribeWorker(ABC):
         if not self.pending_upserts and not self.pending_deletes:
             return
 
+        import time as _time
+        from datetime import datetime as _dt, timezone as _tz
+
         index_name = self.get_index_name()
         upsert_count = len(self.pending_upserts)
         delete_count = len(self.pending_deletes)
@@ -881,6 +884,12 @@ class BaseSubscribeWorker(ABC):
         # Clear buffers immediately to accept new events
         self.pending_upserts = []
         self.pending_deletes = []
+
+        # Stamp wall-clock ms on every upsert so /api/search/impact can count
+        # docs re-indexed after a write across all indexes.
+        mz_ts_int = int(_dt.now(_tz.utc).timestamp() * 1000)
+        for doc in upserts_to_flush:
+            doc["mz_timestamp"] = mz_ts_int
 
         # Flush with retry
         max_attempts = 3

--- a/search-sync/src/base_subscribe_worker.py
+++ b/search-sync/src/base_subscribe_worker.py
@@ -44,6 +44,7 @@ import asyncio
 import json
 import logging
 from abc import ABC, abstractmethod
+from datetime import datetime, timezone
 from typing import Optional
 
 from src.config import get_settings
@@ -861,9 +862,6 @@ class BaseSubscribeWorker(ABC):
         if not self.pending_upserts and not self.pending_deletes:
             return
 
-        import time as _time
-        from datetime import datetime as _dt, timezone as _tz
-
         index_name = self.get_index_name()
         upsert_count = len(self.pending_upserts)
         delete_count = len(self.pending_deletes)
@@ -887,7 +885,7 @@ class BaseSubscribeWorker(ABC):
 
         # Stamp wall-clock ms on every upsert so /api/search/impact can count
         # docs re-indexed after a write across all indexes.
-        mz_ts_int = int(_dt.now(_tz.utc).timestamp() * 1000)
+        mz_ts_int = int(datetime.now(timezone.utc).timestamp() * 1000)
         for doc in upserts_to_flush:
             doc["mz_timestamp"] = mz_ts_int
 

--- a/search-sync/src/embedder.py
+++ b/search-sync/src/embedder.py
@@ -1,0 +1,119 @@
+"""Local CPU vector embedding for orders.
+
+Uses the `fastembed` ONNX runtime with the small BGE model
+(`BAAI/bge-small-en-v1.5`, 384 dims, ~130MB) to embed an order's
+line items into a `knn_vector` for OpenSearch.
+
+Design:
+- ``build_embedding_text`` builds a deterministic text representation
+  of an order's line items: ``"name (category) | name (category) | ..."``.
+- ``compute_hash`` returns a stable MD5 hex digest used to dedup
+  re-embedding work — only re-embed when the embedding text changes.
+- ``Embedder.embed`` wraps fastembed's ``TextEmbedding`` and returns
+  ``list[list[float]]`` (one 384-dim vector per input string).
+
+The model is lazily constructed on first use so importing this module
+is cheap (e.g., for tests), and the model is cached at module level
+to amortize the ~1s warm-up across many calls.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Public constants
+MODEL_NAME = "BAAI/bge-small-en-v1.5"
+EMBEDDING_DIM = 384
+
+
+# Resilient import: in test environments we may not have fastembed installed.
+# We expose `TextEmbedding` as a module-level attribute so tests can
+# `patch("src.embedder.TextEmbedding")` regardless of whether the real
+# package is available.
+try:
+    from fastembed import TextEmbedding  # type: ignore
+except ImportError:  # pragma: no cover - exercised only without fastembed
+    TextEmbedding = None  # type: ignore[assignment]
+
+
+# Module-level cached model instance.
+_model: Optional["TextEmbedding"] = None  # type: ignore[name-defined]
+
+
+def get_model():
+    """Return the (lazily constructed) shared TextEmbedding instance.
+
+    The model is constructed once and reused. Constructing fastembed's
+    ``TextEmbedding`` downloads/loads the ONNX model which is expensive,
+    so we do it lazily on first call.
+    """
+    global _model
+    if _model is None:
+        if TextEmbedding is None:
+            raise RuntimeError(
+                "fastembed is not installed. Add `fastembed` to requirements.txt "
+                "or install it with `pip install fastembed`."
+            )
+        logger.info(f"Loading embedding model: {MODEL_NAME}")
+        _model = TextEmbedding(model_name=MODEL_NAME)
+    return _model
+
+
+def build_embedding_text(line_items: list[dict]) -> str:
+    """Build the canonical text representation of an order's line items.
+
+    Format: ``"<product_name> (<category>) | <product_name> (<category>) | ..."``.
+    Items missing ``product_name`` are skipped. Missing ``category`` becomes
+    an empty string in the parentheses.
+
+    Args:
+        line_items: List of line item dicts from the order document.
+
+    Returns:
+        A single string suitable for hashing and embedding. Empty list
+        returns the empty string.
+    """
+    parts = [
+        f"{li.get('product_name', '')} ({li.get('category', '')})"
+        for li in line_items
+        if li.get("product_name")
+    ]
+    return " | ".join(parts)
+
+
+def compute_hash(text: str) -> str:
+    """Return a deterministic MD5 hex digest of ``text``.
+
+    Used to detect when an order's embedding-relevant fields change —
+    if the hash is unchanged, we can skip re-embedding (price/qty
+    changes don't affect the hash).
+    """
+    return hashlib.md5(text.encode()).hexdigest()
+
+
+class Embedder:
+    """Thin wrapper around fastembed's ``TextEmbedding``.
+
+    Hides the lazy-loading / iterator behavior so callers get a plain
+    ``list[list[float]]`` back.
+    """
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        """Embed ``texts`` into 384-dim float vectors.
+
+        Args:
+            texts: List of strings to embed. Empty list returns ``[]``
+                without loading the model.
+
+        Returns:
+            One ``list[float]`` per input string, in input order. Each
+            vector has ``EMBEDDING_DIM`` (384) elements.
+        """
+        if not texts:
+            return []
+        model = get_model()
+        return [list(v) for v in model.embed(texts)]

--- a/search-sync/src/embedder.py
+++ b/search-sync/src/embedder.py
@@ -116,4 +116,4 @@ class Embedder:
         if not texts:
             return []
         model = get_model()
-        return [list(v) for v in model.embed(texts)]
+        return [[float(x) for x in v] for v in model.embed(texts)]

--- a/search-sync/src/inventory_sync.py
+++ b/search-sync/src/inventory_sync.py
@@ -85,6 +85,7 @@ INVENTORY_INDEX_MAPPING = {
             "availability_status": {"type": "keyword"},
             "low_stock": {"type": "boolean"},
             "effective_updated_at": {"type": "date"},
+            "mz_timestamp": {"type": "long"},
             "search_text": {
                 "type": "text",
                 "analyzer": "ingredient_analyzer",

--- a/search-sync/src/opensearch_client.py
+++ b/search-sync/src/opensearch_client.py
@@ -69,6 +69,7 @@ ORDERS_INDEX_MAPPING = {
             "line_item_count": {"type": "integer"},
             "has_perishable_items": {"type": "boolean"},
             "search_text": {"type": "text"},
+            "mz_timestamp": {"type": "long"},
             # Vector embedding of the order's line items (BAAI/bge-small-en-v1.5)
             "embedding": {
                 "type": "knn_vector",

--- a/search-sync/src/opensearch_client.py
+++ b/search-sync/src/opensearch_client.py
@@ -69,11 +69,21 @@ ORDERS_INDEX_MAPPING = {
             "line_item_count": {"type": "integer"},
             "has_perishable_items": {"type": "boolean"},
             "search_text": {"type": "text"},
+            # Vector embedding of the order's line items (BAAI/bge-small-en-v1.5)
+            "embedding": {
+                "type": "knn_vector",
+                "dimension": 384,
+            },
+            "embedding_text": {"type": "keyword"},
+            "embedded_at": {"type": "date"},
         }
     },
     "settings": {
         "number_of_shards": 1,
         "number_of_replicas": 0,
+        "index": {
+            "knn": True,
+        },
     },
 }
 
@@ -243,6 +253,57 @@ class OpenSearchClient:
         except Exception as e:
             logger.error(f"Bulk upsert failed: {e}")
             return 0, len(documents)
+
+    async def bulk_patch(self, index_name: str, patches: list[dict]) -> tuple[int, int]:
+        """Patch existing documents (update subset of fields without replacing vector).
+
+        Each patch is ``{"_id": "<doc_id>", "doc": {<fields to merge>}}``. Uses
+        OpenSearch ``update`` op_type with ``doc_as_upsert: True`` so an absent
+        document is created from the patch.
+
+        This is intended for "non-vector" updates — e.g., when an order's price
+        changes but its line items (and thus its embedding) did not, we patch
+        only the changed fields and leave the existing ``embedding`` untouched.
+
+        Args:
+            index_name: Target index name.
+            patches: List of ``{"_id": ..., "doc": ...}`` dicts.
+
+        Returns:
+            ``(success_count, error_count)`` tuple.
+        """
+        if not patches:
+            return 0, 0
+
+        actions = []
+        for patch in patches:
+            actions.append(
+                {
+                    "_op_type": "update",
+                    "_index": index_name,
+                    "_id": patch["_id"],
+                    "doc": patch["doc"],
+                    "doc_as_upsert": True,
+                }
+            )
+
+        try:
+            success, errors = await helpers.async_bulk(
+                self.client,
+                actions,
+                raise_on_error=False,
+                raise_on_exception=False,
+            )
+            error_count = len(errors) if errors else 0
+
+            if errors:
+                for error in errors[:5]:
+                    logger.error(f"Bulk patch error detail: {error}")
+
+            return success, error_count
+        except Exception as e:
+            logger.error(f"Bulk patch failed: {e}")
+            return 0, len(patches)
 
     async def bulk_delete(self, index_name: str, doc_ids: list[str]) -> tuple[int, int]:
         """

--- a/search-sync/src/orders_sync.py
+++ b/search-sync/src/orders_sync.py
@@ -345,17 +345,14 @@ class OrdersSyncWorker(BaseSubscribeWorker):
                 doc["embedded_at"] = now_iso
                 full_upserts.append(doc)
 
-        # Stamp the Materialize logical timestamp on every document so the
-        # /api/search/impact endpoint can count docs re-indexed after a write.
-        if timestamp is not None:
-            try:
-                mz_ts_int = int(timestamp)
-                for doc in full_upserts:
-                    doc["mz_timestamp"] = mz_ts_int
-                for patch in patches:
-                    patch["doc"]["mz_timestamp"] = mz_ts_int
-            except (TypeError, ValueError):
-                pass
+        # Stamp wall-clock ms on every document so /api/search/impact can count
+        # docs re-indexed after a write. We use wall-clock (not the SUBSCRIBE
+        # batch timestamp) to stay in the same time domain as the API lower bound.
+        mz_ts_int = int(datetime.now(timezone.utc).timestamp() * 1000)
+        for doc in full_upserts:
+            doc["mz_timestamp"] = mz_ts_int
+        for patch in patches:
+            patch["doc"]["mz_timestamp"] = mz_ts_int
 
         upsert_count = len(full_upserts)
         patch_count = len(patches)

--- a/search-sync/src/orders_sync.py
+++ b/search-sync/src/orders_sync.py
@@ -345,9 +345,8 @@ class OrdersSyncWorker(BaseSubscribeWorker):
                 doc["embedded_at"] = now_iso
                 full_upserts.append(doc)
 
-        # Stamp wall-clock ms on every document so /api/search/impact can count
-        # docs re-indexed after a write. We use wall-clock (not the SUBSCRIBE
-        # batch timestamp) to stay in the same time domain as the API lower bound.
+        # Stamp wall-clock ms on patches (full_upserts are stamped by base _flush_batch
+        # before this override runs, but patches bypass that path).
         mz_ts_int = int(datetime.now(timezone.utc).timestamp() * 1000)
         for doc in full_upserts:
             doc["mz_timestamp"] = mz_ts_int

--- a/search-sync/src/orders_sync.py
+++ b/search-sync/src/orders_sync.py
@@ -119,6 +119,9 @@ ORDERS_INDEX_MAPPING = {
             "line_item_count": {"type": "integer"},
             "has_perishable_items": {"type": "boolean"},
             "search_text": {"type": "text"},
+            # Materialize logical timestamp of the SUBSCRIBE batch that produced this doc.
+            # Used by /api/search/impact to count how many docs were re-indexed after a write.
+            "mz_timestamp": {"type": "long"},
             # Vector embedding of the order's line items (BAAI/bge-small-en-v1.5)
             "embedding": {
                 "type": "knn_vector",
@@ -341,6 +344,18 @@ class OrdersSyncWorker(BaseSubscribeWorker):
                 doc["embedding"] = vec
                 doc["embedded_at"] = now_iso
                 full_upserts.append(doc)
+
+        # Stamp the Materialize logical timestamp on every document so the
+        # /api/search/impact endpoint can count docs re-indexed after a write.
+        if timestamp is not None:
+            try:
+                mz_ts_int = int(timestamp)
+                for doc in full_upserts:
+                    doc["mz_timestamp"] = mz_ts_int
+                for patch in patches:
+                    patch["doc"]["mz_timestamp"] = mz_ts_int
+            except (TypeError, ValueError):
+                pass
 
         upsert_count = len(full_upserts)
         patch_count = len(patches)

--- a/search-sync/src/orders_sync.py
+++ b/search-sync/src/orders_sync.py
@@ -167,7 +167,8 @@ class OrdersSyncWorker(BaseSubscribeWorker):
         super().__init__(os_client)
         # Maps order_id -> last embedded MD5 hash. Stored in memory only;
         # rebuilds naturally on restart since the next change will trigger
-        # a re-embed.
+        # a re-embed. Unbounded — acceptable for this demo, but would need a
+        # TTL or size cap for a long-running production worker.
         self._hash_cache: dict[str, str] = {}
         self._embedder = Embedder()
 
@@ -345,8 +346,8 @@ class OrdersSyncWorker(BaseSubscribeWorker):
                 doc["embedded_at"] = now_iso
                 full_upserts.append(doc)
 
-        # Stamp wall-clock ms on patches (full_upserts are stamped by base _flush_batch
-        # before this override runs, but patches bypass that path).
+        # Stamp wall-clock ms on all docs. This is a full override with no super() call,
+        # so both full_upserts and patches must be stamped here.
         mz_ts_int = int(datetime.now(timezone.utc).timestamp() * 1000)
         for doc in full_upserts:
             doc["mz_timestamp"] = mz_ts_int

--- a/search-sync/src/orders_sync.py
+++ b/search-sync/src/orders_sync.py
@@ -26,14 +26,22 @@ Example:
             logger.info("Graceful shutdown complete")
 """
 
+import asyncio
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 from src.base_subscribe_worker import BaseSubscribeWorker
+from src.embedder import Embedder, build_embedding_text, compute_hash
 from src.opensearch_client import OpenSearchClient
 
 logger = logging.getLogger(__name__)
+
+
+# Fields that are excluded from a "patch-only" update — i.e., these are
+# either the vector itself or fields whose source is the embedding pipeline.
+# When line items are unchanged we patch every other field but leave these alone.
+_EMBEDDING_FIELDS = {"embedding", "embedding_text", "embedded_at"}
 
 
 # Orders index mapping - matches ORDERS_INDEX_MAPPING from opensearch_client.py
@@ -111,11 +119,21 @@ ORDERS_INDEX_MAPPING = {
             "line_item_count": {"type": "integer"},
             "has_perishable_items": {"type": "boolean"},
             "search_text": {"type": "text"},
+            # Vector embedding of the order's line items (BAAI/bge-small-en-v1.5)
+            "embedding": {
+                "type": "knn_vector",
+                "dimension": 384,
+            },
+            "embedding_text": {"type": "keyword"},
+            "embedded_at": {"type": "date"},
         }
     },
     "settings": {
         "number_of_shards": 1,
         "number_of_replicas": 0,
+        "index": {
+            "knn": True,
+        },
     },
 }
 
@@ -133,7 +151,22 @@ class OrdersSyncWorker(BaseSubscribeWorker):
 
     The worker syncs enriched order data including customer info, store
     details, delivery tasks, and line items with dynamic pricing as nested documents.
+
+    Vector embeddings:
+        Each order document also carries a 384-dim ``knn_vector`` embedding
+        of its line items (text: ``"name (category) | name (category) | ..."``).
+        We use an MD5 hash of that text as a dedup key — only re-embed when
+        the embedding text changes. Price/quantity-only updates use
+        ``bulk_patch`` to avoid recomputing the vector.
     """
+
+    def __init__(self, os_client: OpenSearchClient):
+        super().__init__(os_client)
+        # Maps order_id -> last embedded MD5 hash. Stored in memory only;
+        # rebuilds naturally on restart since the next change will trigger
+        # a re-embed.
+        self._hash_cache: dict[str, str] = {}
+        self._embedder = Embedder()
 
     def get_view_name(self) -> str:
         """Return Materialize view name."""
@@ -239,6 +272,154 @@ class OrdersSyncWorker(BaseSubscribeWorker):
         except Exception as e:
             logger.error(f"Error transforming order event: {e}", exc_info=True)
             return None
+
+    async def _flush_batch(self, timestamp=None):
+        """Flush pending events to OpenSearch with embedding-aware routing.
+
+        Splits ``self.pending_upserts`` into two groups based on whether
+        the order's line items have changed since we last embedded them:
+
+        - **Hash changed (or new)**: embed the text, attach the vector
+          (and ``embedding_text`` / ``embedded_at`` metadata), and
+          ``bulk_upsert`` the full document.
+        - **Hash unchanged**: build a patch with all fields except the
+          embedding ones and ``bulk_patch`` it. The existing vector in
+          OpenSearch is left untouched.
+
+        Pending deletes still flow through ``bulk_delete`` unchanged.
+
+        Args:
+            timestamp: Optional Materialize logical timestamp for logging.
+        """
+        if not self.pending_upserts and not self.pending_deletes:
+            return
+
+        index_name = self.get_index_name()
+
+        # Capture and clear pending buffers before async work so new events
+        # can accumulate while we flush.
+        upserts_to_process = self.pending_upserts
+        deletes_to_flush = self.pending_deletes
+        self.pending_upserts = []
+        self.pending_deletes = []
+
+        # Split upserts into "needs full embedding" vs "patch only"
+        full_upserts: list[dict] = []
+        patches: list[dict] = []
+
+        # Bulk-embed all docs that need embedding in one shot.
+        docs_needing_embedding: list[dict] = []
+        texts_to_embed: list[str] = []
+
+        for doc in upserts_to_process:
+            order_id = doc.get("order_id")
+            line_items = doc.get("line_items") or []
+            embedding_text = build_embedding_text(line_items)
+            new_hash = compute_hash(embedding_text)
+            prev_hash = self._hash_cache.get(order_id)
+
+            if prev_hash == new_hash and order_id is not None:
+                # Embedding text unchanged -> patch non-vector fields only.
+                patch_doc = {
+                    k: v for k, v in doc.items() if k not in _EMBEDDING_FIELDS
+                }
+                patches.append({"_id": order_id, "doc": patch_doc})
+            else:
+                # New order or line items changed -> embed + full upsert.
+                doc["embedding_text"] = embedding_text
+                docs_needing_embedding.append(doc)
+                texts_to_embed.append(embedding_text)
+                # Update hash cache eagerly; if the embedding fails the
+                # next event will reset it via re-embedding anyway.
+                if order_id is not None:
+                    self._hash_cache[order_id] = new_hash
+
+        if docs_needing_embedding:
+            vectors = self._embedder.embed(texts_to_embed)
+            now_iso = datetime.now(timezone.utc).isoformat()
+            for doc, vec in zip(docs_needing_embedding, vectors):
+                doc["embedding"] = vec
+                doc["embedded_at"] = now_iso
+                full_upserts.append(doc)
+
+        upsert_count = len(full_upserts)
+        patch_count = len(patches)
+        delete_count = len(deletes_to_flush)
+
+        ts_str = f"mz_ts={timestamp} " if timestamp else ""
+        ops = []
+        if upsert_count:
+            ops.append(f"{upsert_count} upserts (embed)")
+        if patch_count:
+            ops.append(f"{patch_count} patches (no-embed)")
+        if delete_count:
+            ops.append(f"{delete_count} deletes")
+        if ops:
+            logger.debug(
+                f"  Bulk request @ {ts_str}-> {index_name}: {', '.join(ops)}"
+            )
+
+        # Flush with retry, mirroring the base-class behavior.
+        max_attempts = 3
+        for attempt in range(max_attempts):
+            try:
+                if full_upserts:
+                    success, errors = await self.os.bulk_upsert(
+                        index_name, full_upserts
+                    )
+                    logger.info(
+                        f"Upsert (with embedding) result: {success} succeeded, "
+                        f"{errors} errors"
+                    )
+
+                if patches:
+                    success, errors = await self.os.bulk_patch(
+                        index_name, patches
+                    )
+                    logger.info(
+                        f"Patch (no embedding) result: {success} succeeded, "
+                        f"{errors} errors"
+                    )
+
+                if deletes_to_flush:
+                    success, errors = await self.os.bulk_delete(
+                        index_name, deletes_to_flush
+                    )
+                    logger.info(
+                        f"Delete result: {success} succeeded, {errors} errors"
+                    )
+
+                self.events_processed += upsert_count + patch_count + delete_count
+                self.flush_count += 1
+                return
+
+            except Exception as e:
+                if attempt < max_attempts - 1:
+                    retry_delay = (attempt + 1) * 2
+                    logger.warning(
+                        f"Flush attempt {attempt + 1}/{max_attempts} failed: {e}. "
+                        f"Retrying in {retry_delay}s..."
+                    )
+                    await asyncio.sleep(retry_delay)
+                else:
+                    logger.error(
+                        f"Flush failed after {max_attempts} attempts: {e}",
+                        exc_info=True,
+                    )
+                    # Re-queue full upserts (unembedded form) and patches/deletes.
+                    # Strip embedding-derived fields so the next attempt re-runs
+                    # the embedder cleanly.
+                    for doc in full_upserts:
+                        for k in _EMBEDDING_FIELDS:
+                            doc.pop(k, None)
+                    self.pending_upserts.extend(full_upserts)
+                    # Convert patches back to docs (best effort) so they retry.
+                    for p in patches:
+                        self.pending_upserts.append(
+                            {"order_id": p["_id"], **p["doc"]}
+                        )
+                    self.pending_deletes.extend(deletes_to_flush)
+                    raise
 
     def _format_datetime(self, value) -> Optional[str]:
         """Format datetime value for OpenSearch.

--- a/search-sync/src/orders_sync.py
+++ b/search-sync/src/orders_sync.py
@@ -310,6 +310,7 @@ class OrdersSyncWorker(BaseSubscribeWorker):
         # Split upserts into "needs full embedding" vs "patch only"
         full_upserts: list[dict] = []
         patches: list[dict] = []
+        pending_cache_updates: list[tuple[str, str]] = []
 
         # Bulk-embed all docs that need embedding in one shot.
         docs_needing_embedding: list[dict] = []
@@ -333,10 +334,8 @@ class OrdersSyncWorker(BaseSubscribeWorker):
                 doc["embedding_text"] = embedding_text
                 docs_needing_embedding.append(doc)
                 texts_to_embed.append(embedding_text)
-                # Update hash cache eagerly; if the embedding fails the
-                # next event will reset it via re-embedding anyway.
                 if order_id is not None:
-                    self._hash_cache[order_id] = new_hash
+                    pending_cache_updates.append((order_id, new_hash))
 
         if docs_needing_embedding:
             vectors = self._embedder.embed(texts_to_embed)
@@ -403,6 +402,8 @@ class OrdersSyncWorker(BaseSubscribeWorker):
 
                 self.events_processed += upsert_count + patch_count + delete_count
                 self.flush_count += 1
+                for order_id, new_hash in pending_cache_updates:
+                    self._hash_cache[order_id] = new_hash
                 return
 
             except Exception as e:

--- a/search-sync/src/orders_sync.py
+++ b/search-sync/src/orders_sync.py
@@ -421,31 +421,85 @@ class OrdersSyncWorker(BaseSubscribeWorker):
                     self.pending_deletes.extend(deletes_to_flush)
                     raise
 
+    async def _initial_hydration(self):
+        """Override initial hydration to batch-embed all documents before indexing."""
+        from src.mz_client_subscribe import MaterializeSubscribeClient
+
+        view_name = self.get_view_name()
+        index_name = self.get_index_name()
+
+        logger.info(f"Starting initial hydration with embeddings from {view_name}...")
+
+        try:
+            temp_client = MaterializeSubscribeClient()
+            try:
+                await temp_client.connect()
+                rows = await temp_client.query(f"SELECT * FROM {view_name}")
+                if not rows:
+                    logger.info("No existing data to hydrate")
+                    return
+                logger.info(f"Retrieved {len(rows)} rows from Materialize")
+
+                documents = []
+                for row in rows:
+                    doc = self.transform_event_to_doc(row)
+                    if doc:
+                        documents.append(doc)
+
+                if not documents:
+                    logger.warning("No valid documents after transformation")
+                    return
+
+                # Batch-embed all documents in one shot
+                self._embed_documents(documents)
+
+                logger.info(f"Bulk loading {len(documents)} documents with embeddings into OpenSearch...")
+                success, errors = await self.os.bulk_upsert(index_name, documents)
+                if errors > 0:
+                    logger.warning(f"Initial hydration completed with {errors} errors")
+                else:
+                    logger.info(f"Initial hydration complete: {success} documents loaded")
+                self.events_processed += success
+            finally:
+                await temp_client.close()
+        except Exception as e:
+            logger.error(f"Initial hydration failed: {e}", exc_info=True)
+            logger.warning("Continuing with SUBSCRIBE streaming despite hydration failure")
+
+    def _embed_documents(self, documents: list[dict]) -> None:
+        """Embed a batch of documents in-place, updating hash cache."""
+        texts = []
+        for doc in documents:
+            line_items = doc.get("line_items") or []
+            text = build_embedding_text(line_items)
+            doc["embedding_text"] = text
+            texts.append(text)
+
+        if not texts:
+            return
+
+        vectors = self._embedder.embed(texts)
+        now_iso = datetime.now(timezone.utc).isoformat()
+        for doc, vec in zip(documents, vectors):
+            doc["embedding"] = vec
+            doc["embedded_at"] = now_iso
+            order_id = doc.get("order_id")
+            if order_id:
+                self._hash_cache[order_id] = compute_hash(doc["embedding_text"])
+
     def _format_datetime(self, value) -> Optional[str]:
-        """Format datetime value for OpenSearch.
-
-        Handles multiple input types:
-        - None → None
-        - str → unchanged (already ISO format)
-        - datetime → ISO format string
-        - other → str(value)
-
-        Args:
-            value: Datetime value to format
-
-        Returns:
-            ISO format string or None
-        """
+        """Format datetime value for OpenSearch ISO 8601."""
         if value is None:
             return None
 
-        # Already a string, return as-is
-        if isinstance(value, str):
-            return value
-
-        # Convert datetime to ISO format
         if isinstance(value, datetime):
             return value.isoformat()
 
-        # Fallback: convert to string
+        if isinstance(value, str):
+            # Normalize PostgreSQL-style "YYYY-MM-DD HH:MM:SS+TZ" → ISO 8601
+            # OpenSearch requires the T separator between date and time.
+            if len(value) >= 19 and value[10] == " ":
+                value = value[:10] + "T" + value[11:]
+            return value
+
         return str(value)

--- a/search-sync/tests/conftest.py
+++ b/search-sync/tests/conftest.py
@@ -22,12 +22,22 @@ def mock_os_client():
     client = AsyncMock()
     client.setup_indices = AsyncMock()
     client.bulk_upsert = AsyncMock(return_value=(0, 0))
+    client.bulk_patch = AsyncMock(return_value=(0, 0))
+    client.bulk_delete = AsyncMock(return_value=(0, 0))
     client.search_orders = AsyncMock(return_value=[])
     client.health_check = AsyncMock(return_value=True)
     client.ensure_index = AsyncMock()
     client.close = AsyncMock()
     client.orders_index = "orders"
     return client
+
+
+@pytest.fixture
+def mock_embedder():
+    """Create a mock Embedder that returns deterministic 384-dim vectors."""
+    embedder = MagicMock()
+    embedder.embed.return_value = [[0.1] * 384]
+    return embedder
 
 
 @pytest.fixture

--- a/search-sync/tests/test_embedder.py
+++ b/search-sync/tests/test_embedder.py
@@ -1,0 +1,192 @@
+"""Tests for the embedder module.
+
+Covers:
+- build_embedding_text(line_items): formats line items into a single embedding string
+- compute_hash(text): deterministic MD5 hex string
+- Embedder.embed(texts): wraps fastembed TextEmbedding (mocked here)
+"""
+
+import hashlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestBuildEmbeddingText:
+    """Tests for build_embedding_text()."""
+
+    def test_returns_empty_string_for_empty_list(self):
+        """Empty line items list returns empty string."""
+        from src.embedder import build_embedding_text
+
+        assert build_embedding_text([]) == ""
+
+    def test_formats_single_line_item(self):
+        """Single line item is formatted as 'name (category)'."""
+        from src.embedder import build_embedding_text
+
+        line_items = [{"product_name": "Whole Milk", "category": "Dairy"}]
+        assert build_embedding_text(line_items) == "Whole Milk (Dairy)"
+
+    def test_joins_multiple_line_items_with_pipe(self):
+        """Multiple items joined by ' | '."""
+        from src.embedder import build_embedding_text
+
+        line_items = [
+            {"product_name": "Whole Milk", "category": "Dairy"},
+            {"product_name": "Sourdough Bread", "category": "Bakery"},
+            {"product_name": "Bananas", "category": "Produce"},
+        ]
+        result = build_embedding_text(line_items)
+        assert (
+            result
+            == "Whole Milk (Dairy) | Sourdough Bread (Bakery) | Bananas (Produce)"
+        )
+
+    def test_skips_items_without_product_name(self):
+        """Line items without product_name are skipped."""
+        from src.embedder import build_embedding_text
+
+        line_items = [
+            {"product_name": "Whole Milk", "category": "Dairy"},
+            {"category": "Bakery"},  # missing product_name
+            {"product_name": "Bananas", "category": "Produce"},
+        ]
+        result = build_embedding_text(line_items)
+        assert result == "Whole Milk (Dairy) | Bananas (Produce)"
+
+    def test_handles_missing_category(self):
+        """Missing category becomes empty string in parentheses."""
+        from src.embedder import build_embedding_text
+
+        line_items = [{"product_name": "Mystery Item"}]
+        assert build_embedding_text(line_items) == "Mystery Item ()"
+
+
+class TestComputeHash:
+    """Tests for compute_hash()."""
+
+    def test_returns_md5_hex_string(self):
+        """Returns 32-character hex MD5 string."""
+        from src.embedder import compute_hash
+
+        result = compute_hash("hello world")
+        assert isinstance(result, str)
+        assert len(result) == 32
+        # All chars must be lowercase hex
+        assert all(c in "0123456789abcdef" for c in result)
+
+    def test_is_deterministic(self):
+        """Same input produces same hash."""
+        from src.embedder import compute_hash
+
+        text = "Whole Milk (Dairy) | Bananas (Produce)"
+        assert compute_hash(text) == compute_hash(text)
+
+    def test_matches_md5_of_input(self):
+        """Hash matches the MD5 hex of the UTF-8 encoded input."""
+        from src.embedder import compute_hash
+
+        text = "the quick brown fox"
+        expected = hashlib.md5(text.encode()).hexdigest()
+        assert compute_hash(text) == expected
+
+    def test_different_inputs_produce_different_hashes(self):
+        """Different inputs produce different hashes."""
+        from src.embedder import compute_hash
+
+        assert compute_hash("foo") != compute_hash("bar")
+
+    def test_handles_empty_string(self):
+        """Empty string produces a valid MD5 hash."""
+        from src.embedder import compute_hash
+
+        result = compute_hash("")
+        assert result == hashlib.md5(b"").hexdigest()
+
+
+class TestEmbedder:
+    """Tests for Embedder class."""
+
+    def test_embed_empty_list_returns_empty_list(self):
+        """Embedding an empty list returns []."""
+        # Reset module-level model cache so we don't accidentally instantiate fastembed
+        with patch("src.embedder.TextEmbedding") as mock_cls:
+            import src.embedder as embedder_mod
+
+            embedder_mod._model = None  # reset cache
+
+            embedder = embedder_mod.Embedder()
+            result = embedder.embed([])
+            assert result == []
+            # Model should not be loaded for empty input
+            mock_cls.assert_not_called()
+
+    def test_embed_returns_list_of_lists_of_floats(self):
+        """Embedding returns list[list[float]] with correct dim."""
+        with patch("src.embedder.TextEmbedding") as mock_cls:
+            import src.embedder as embedder_mod
+
+            embedder_mod._model = None
+
+            mock_instance = MagicMock()
+            mock_cls.return_value = mock_instance
+            mock_instance.embed.return_value = iter(
+                [[0.1] * 384, [0.2] * 384]
+            )
+
+            embedder = embedder_mod.Embedder()
+            vectors = embedder.embed(["text one", "text two"])
+
+            assert isinstance(vectors, list)
+            assert len(vectors) == 2
+            assert all(isinstance(v, list) for v in vectors)
+            assert all(len(v) == 384 for v in vectors)
+            assert all(isinstance(x, float) for x in vectors[0])
+
+    def test_embed_uses_fastembed_text_embedding(self):
+        """Embedder calls TextEmbedding under the hood."""
+        with patch("src.embedder.TextEmbedding") as mock_cls:
+            import src.embedder as embedder_mod
+
+            embedder_mod._model = None
+
+            mock_instance = MagicMock()
+            mock_cls.return_value = mock_instance
+            mock_instance.embed.return_value = iter([[0.5] * 384])
+
+            embedder = embedder_mod.Embedder()
+            embedder.embed(["the quick brown fox"])
+
+            # Model should be constructed lazily with bge-small-en-v1.5
+            mock_cls.assert_called_once()
+            call_kwargs = mock_cls.call_args.kwargs
+            assert call_kwargs.get("model_name") == "BAAI/bge-small-en-v1.5"
+            # And .embed() should have been called with the texts
+            mock_instance.embed.assert_called_once_with(["the quick brown fox"])
+
+    def test_embedding_dim_constant_is_384(self):
+        """The EMBEDDING_DIM constant is 384."""
+        from src.embedder import EMBEDDING_DIM
+
+        assert EMBEDDING_DIM == 384
+
+    def test_model_name_constant_is_bge_small(self):
+        """The MODEL_NAME constant is the BAAI bge-small-en-v1.5 model."""
+        from src.embedder import MODEL_NAME
+
+        assert MODEL_NAME == "BAAI/bge-small-en-v1.5"
+
+    def test_get_model_caches_instance(self):
+        """get_model() returns the same instance across calls."""
+        with patch("src.embedder.TextEmbedding") as mock_cls:
+            import src.embedder as embedder_mod
+
+            embedder_mod._model = None
+            mock_cls.return_value = MagicMock()
+
+            m1 = embedder_mod.get_model()
+            m2 = embedder_mod.get_model()
+            assert m1 is m2
+            # Constructed exactly once
+            assert mock_cls.call_count == 1

--- a/search-sync/tests/test_opensearch_client.py
+++ b/search-sync/tests/test_opensearch_client.py
@@ -183,6 +183,119 @@ class TestBulkUpsert:
             assert errors == 1
 
 
+class TestBulkPatch:
+    """Tests for OpenSearchClient.bulk_patch."""
+
+    @pytest.fixture
+    def client(self):
+        """Create client with mocked internal client."""
+        with patch("src.opensearch_client.get_settings") as mock_settings:
+            mock_settings.return_value = MagicMock(
+                os_host="localhost",
+                os_port=9200,
+                os_user=None,
+                os_password=None,
+            )
+            with patch("src.opensearch_client.AsyncOpenSearch"):
+                from src.opensearch_client import OpenSearchClient
+
+                client = OpenSearchClient()
+                client.client = AsyncMock()
+                return client
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_for_empty_list(self, client):
+        """Returns (0, 0) for empty patch list and does not call helpers."""
+        with patch("src.opensearch_client.helpers.async_bulk") as mock_bulk:
+            success, errors = await client.bulk_patch("test_index", [])
+
+            assert success == 0
+            assert errors == 0
+            mock_bulk.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_uses_update_op_type(self, client):
+        """Uses update _op_type (not index)."""
+        with patch("src.opensearch_client.helpers.async_bulk") as mock_bulk:
+            mock_bulk.return_value = (1, [])
+
+            patches = [
+                {
+                    "_id": "order:FM-1001",
+                    "doc": {"order_total_amount": 49.99},
+                }
+            ]
+
+            await client.bulk_patch("test_index", patches)
+
+            actions = list(mock_bulk.call_args.args[1])
+            assert actions[0]["_op_type"] == "update"
+
+    @pytest.mark.asyncio
+    async def test_passes_doc_as_upsert_true(self, client):
+        """Sets doc_as_upsert: True so first patch creates the doc."""
+        with patch("src.opensearch_client.helpers.async_bulk") as mock_bulk:
+            mock_bulk.return_value = (1, [])
+
+            patches = [{"_id": "order:FM-1001", "doc": {"order_status": "DELIVERED"}}]
+
+            await client.bulk_patch("test_index", patches)
+
+            actions = list(mock_bulk.call_args.args[1])
+            assert actions[0]["doc_as_upsert"] is True
+
+    @pytest.mark.asyncio
+    async def test_passes_doc_field(self, client):
+        """Forwards the patch's `doc` field to the bulk action."""
+        with patch("src.opensearch_client.helpers.async_bulk") as mock_bulk:
+            mock_bulk.return_value = (1, [])
+
+            patch_doc = {"order_status": "DELIVERED", "order_total_amount": 12.34}
+            patches = [{"_id": "order:FM-1001", "doc": patch_doc}]
+
+            await client.bulk_patch("test_index", patches)
+
+            actions = list(mock_bulk.call_args.args[1])
+            assert actions[0]["doc"] == patch_doc
+            assert actions[0]["_id"] == "order:FM-1001"
+            assert actions[0]["_index"] == "test_index"
+
+    @pytest.mark.asyncio
+    async def test_returns_success_and_error_counts(self, client):
+        """Returns (success_count, error_count) tuple from helpers.async_bulk."""
+        with patch("src.opensearch_client.helpers.async_bulk") as mock_bulk:
+            # 2 succeeded, 1 errored
+            mock_bulk.return_value = (2, [{"error": "boom"}])
+
+            patches = [
+                {"_id": "order:1", "doc": {"order_status": "DELIVERED"}},
+                {"_id": "order:2", "doc": {"order_status": "DELIVERED"}},
+                {"_id": "order:3", "doc": {"order_status": "DELIVERED"}},
+            ]
+
+            success, errors = await client.bulk_patch("test_index", patches)
+
+            assert success == 2
+            assert errors == 1
+
+    @pytest.mark.asyncio
+    async def test_creates_one_action_per_patch(self, client):
+        """Builds exactly one bulk action per patch entry."""
+        with patch("src.opensearch_client.helpers.async_bulk") as mock_bulk:
+            mock_bulk.return_value = (3, [])
+
+            patches = [
+                {"_id": "order:1", "doc": {"a": 1}},
+                {"_id": "order:2", "doc": {"a": 2}},
+                {"_id": "order:3", "doc": {"a": 3}},
+            ]
+
+            await client.bulk_patch("test_index", patches)
+
+            actions = list(mock_bulk.call_args.args[1])
+            assert len(actions) == 3
+
+
 class TestSearchOrders:
     """Tests for OpenSearchClient.search_orders."""
 

--- a/search-sync/tests/test_orders_sync.py
+++ b/search-sync/tests/test_orders_sync.py
@@ -7,6 +7,217 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
+class TestOrdersSyncWorkerEmbedding:
+    """Tests for the local-CPU vector embedding pipeline in OrdersSyncWorker.
+
+    Behavior under test:
+    - First time we see an order (no hash in cache) -> embed + bulk_upsert
+      with `embedding`, `embedding_text`, `embedded_at` fields populated.
+    - Same order, same line items (hash unchanged) -> NO embed call,
+      use bulk_patch with the non-vector fields only.
+    - Same order, different line items (hash changed) -> re-embed +
+      bulk_upsert with the fresh vector.
+    """
+
+    @pytest.fixture
+    def worker(self, mock_os_client, mock_embedder):
+        """Build an OrdersSyncWorker with mocked OS client and embedder."""
+        with patch("src.base_subscribe_worker.get_settings") as mock_settings:
+            mock_settings.return_value = MagicMock(
+                use_subscribe=True,
+                backpressure_threshold=10000,
+                backpressure_resume=5000,
+                retry_initial_delay=1,
+                retry_max_delay=10,
+            )
+            from src.orders_sync import OrdersSyncWorker
+
+            w = OrdersSyncWorker(mock_os_client)
+            w._embedder = mock_embedder
+            return w
+
+    def _doc(self, order_id="order:FM-1001", line_items=None, **overrides):
+        """Build a minimal order doc dict (already in OS doc form)."""
+        doc = {
+            "order_id": order_id,
+            "order_number": order_id.split(":")[-1],
+            "order_status": "OUT_FOR_DELIVERY",
+            "store_id": "store:BK-01",
+            "customer_id": "customer:101",
+            "order_total_amount": 45.99,
+            "line_items": line_items
+            if line_items is not None
+            else [
+                {"product_name": "Whole Milk", "category": "Dairy"},
+                {"product_name": "Bananas", "category": "Produce"},
+            ],
+            "line_item_count": 2,
+            "has_perishable_items": True,
+        }
+        doc.update(overrides)
+        return doc
+
+    @pytest.mark.asyncio
+    async def test_new_order_embeds_and_upserts(
+        self, worker, mock_os_client, mock_embedder
+    ):
+        """A new order (not in hash cache) is embedded + bulk_upserted."""
+        mock_embedder.embed.return_value = [[0.42] * 384]
+
+        worker.pending_upserts = [self._doc()]
+        await worker._flush_batch()
+
+        # Embedder was called exactly once for the new order
+        mock_embedder.embed.assert_called_once()
+        # bulk_upsert was called with the doc carrying embedding + embedded_at
+        mock_os_client.bulk_upsert.assert_called_once()
+        upsert_args = mock_os_client.bulk_upsert.call_args
+        assert upsert_args.args[0] == "orders"
+        upserted_doc = upsert_args.args[1][0]
+        assert upserted_doc["embedding"] == [0.42] * 384
+        assert upserted_doc["embedding_text"] == (
+            "Whole Milk (Dairy) | Bananas (Produce)"
+        )
+        assert "embedded_at" in upserted_doc
+        # bulk_patch should NOT have been called
+        mock_os_client.bulk_patch.assert_not_called()
+        # Hash cache populated
+        assert "order:FM-1001" in worker._hash_cache
+
+    @pytest.mark.asyncio
+    async def test_unchanged_line_items_skips_embed_and_patches(
+        self, worker, mock_os_client, mock_embedder
+    ):
+        """When line items are unchanged, do NOT re-embed and use bulk_patch."""
+        # First flush: embed + upsert
+        mock_embedder.embed.return_value = [[0.1] * 384]
+        worker.pending_upserts = [self._doc()]
+        await worker._flush_batch()
+        assert mock_embedder.embed.call_count == 1
+        assert mock_os_client.bulk_upsert.call_count == 1
+
+        # Second flush: same line items, only price changed -> patch only
+        worker.pending_upserts = [self._doc(order_total_amount=99.99)]
+        await worker._flush_batch()
+
+        # Embed was NOT called again
+        assert mock_embedder.embed.call_count == 1
+        # bulk_patch was called for the price-only change
+        mock_os_client.bulk_patch.assert_called_once()
+        patch_args = mock_os_client.bulk_patch.call_args
+        assert patch_args.args[0] == "orders"
+        patches = patch_args.args[1]
+        assert len(patches) == 1
+        assert patches[0]["_id"] == "order:FM-1001"
+        # Patch should NOT contain the vector (it's untouched)
+        assert "embedding" not in patches[0]["doc"]
+        # Patch DOES contain the changed price field
+        assert patches[0]["doc"]["order_total_amount"] == 99.99
+        # bulk_upsert was not called the second time
+        assert mock_os_client.bulk_upsert.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_changed_line_items_reembeds_and_upserts(
+        self, worker, mock_os_client, mock_embedder
+    ):
+        """When line items change, re-embed and use bulk_upsert."""
+        # First flush
+        mock_embedder.embed.return_value = [[0.1] * 384]
+        worker.pending_upserts = [self._doc()]
+        await worker._flush_batch()
+        assert mock_embedder.embed.call_count == 1
+
+        # Second flush: line items DIFFERENT -> re-embed
+        new_items = [
+            {"product_name": "Sourdough Bread", "category": "Bakery"},
+            {"product_name": "Bananas", "category": "Produce"},
+        ]
+        mock_embedder.embed.return_value = [[0.9] * 384]
+        worker.pending_upserts = [self._doc(line_items=new_items)]
+        await worker._flush_batch()
+
+        # Embedder was called again for the changed items
+        assert mock_embedder.embed.call_count == 2
+        # bulk_upsert was called twice (both flushes had a hash change)
+        assert mock_os_client.bulk_upsert.call_count == 2
+        # No patches
+        mock_os_client.bulk_patch.assert_not_called()
+        # Latest upsert carries the new vector
+        last_upsert = mock_os_client.bulk_upsert.call_args.args[1][0]
+        assert last_upsert["embedding"] == [0.9] * 384
+        assert "Sourdough Bread (Bakery)" in last_upsert["embedding_text"]
+
+    @pytest.mark.asyncio
+    async def test_build_embedding_text_called_with_line_items(
+        self, worker, mock_os_client, mock_embedder
+    ):
+        """build_embedding_text is invoked with the order's line_items."""
+        mock_embedder.embed.return_value = [[0.0] * 384]
+
+        with patch(
+            "src.orders_sync.build_embedding_text",
+            wraps=__import__(
+                "src.embedder", fromlist=["build_embedding_text"]
+            ).build_embedding_text,
+        ) as spy:
+            worker.pending_upserts = [self._doc()]
+            await worker._flush_batch()
+
+        # Called once per doc in the batch
+        assert spy.call_count == 1
+        called_with = spy.call_args.args[0]
+        assert called_with == [
+            {"product_name": "Whole Milk", "category": "Dairy"},
+            {"product_name": "Bananas", "category": "Produce"},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_worker_initializes_hash_cache_and_embedder(self, mock_os_client):
+        """Worker has a hash cache dict and embedder attribute on init."""
+        with patch("src.base_subscribe_worker.get_settings") as mock_settings:
+            mock_settings.return_value = MagicMock(
+                use_subscribe=True,
+                backpressure_threshold=10000,
+                backpressure_resume=5000,
+                retry_initial_delay=1,
+                retry_max_delay=10,
+            )
+            from src.orders_sync import OrdersSyncWorker
+
+            w = OrdersSyncWorker(mock_os_client)
+
+            assert isinstance(w._hash_cache, dict)
+            assert w._hash_cache == {}
+            assert w._embedder is not None
+
+    @pytest.mark.asyncio
+    async def test_flush_batch_empty_does_nothing(
+        self, worker, mock_os_client, mock_embedder
+    ):
+        """Empty pending lists results in no calls."""
+        worker.pending_upserts = []
+        worker.pending_deletes = []
+
+        await worker._flush_batch()
+
+        mock_embedder.embed.assert_not_called()
+        mock_os_client.bulk_upsert.assert_not_called()
+        mock_os_client.bulk_patch.assert_not_called()
+        mock_os_client.bulk_delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_orders_index_mapping_includes_knn_vector(self):
+        """The orders index mapping advertises a 384-dim knn_vector embedding field."""
+        from src.opensearch_client import ORDERS_INDEX_MAPPING
+
+        props = ORDERS_INDEX_MAPPING["mappings"]["properties"]
+        assert "embedding" in props
+        assert props["embedding"]["type"] == "knn_vector"
+        assert props["embedding"]["dimension"] == 384
+        assert props["embedding_text"]["type"] == "keyword"
+        assert props["embedded_at"]["type"] == "date"
+
+
 class TestOrdersSyncWorker:
     """Tests for OrdersSyncWorker."""
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -39,7 +39,7 @@
         "jsdom": "^23.2.0",
         "postcss": "^8.4.33",
         "tailwindcss": "^3.4.1",
-        "typescript": "^5.3.3",
+        "typescript": "^5.9.3",
         "vite": "^5.0.11",
         "vitest": "^1.2.0"
       }

--- a/web/package.json
+++ b/web/package.json
@@ -42,7 +42,7 @@
     "jsdom": "^23.2.0",
     "postcss": "^8.4.33",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5.3.3",
+    "typescript": "^5.9.3",
     "vite": "^5.0.11",
     "vitest": "^1.2.0"
   }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -686,9 +686,9 @@ export const searchApi = {
     apiClient.get<OpenSearchResponse>('/api/search/orders', {
       params: { q: query, limit: limit || 5 },
     }),
-  vectorSearchOrders: (query: string, limit?: number) =>
+  vectorSearchOrders: (query: string, limit?: number, filters?: { store_zone?: string; order_status?: string }) =>
     apiClient.get<VectorSearchResponse>('/api/search/vector/orders', {
-      params: { q: query, limit: limit || 3 },
+      params: { q: query, limit: limit || 3, ...filters },
     }),
   indexImpact: (since_mz_timestamp: number) =>
     apiClient.get<{ impacted: number; total: number; pct: number }>('/api/search/impact', {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -641,6 +641,7 @@ export type OpenSearchResponse = Record<string, any>
 
 export type VectorLineItem = {
   line_id?: string;
+  product_id?: string;
   product_name?: string;
   category?: string;
   quantity?: number;

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -639,9 +639,33 @@ export const metricsApi = {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type OpenSearchResponse = Record<string, any>
 
+export type VectorSearchResult = {
+  order_id: string;
+  score: number;
+  embedding_text: string;
+  embedded_at: string | null;
+  order_number?: string;
+  order_status?: string;
+  customer_name?: string;
+  store_name?: string;
+  store_zone?: string;
+  order_total_amount?: number;
+  effective_updated_at?: string;
+}
+
+export type VectorSearchResponse = {
+  results: VectorSearchResult[];
+  query: string;
+  total: number;
+}
+
 export const searchApi = {
   searchOrders: (query: string, limit?: number) =>
     apiClient.get<OpenSearchResponse>('/api/search/orders', {
       params: { q: query, limit: limit || 5 },
+    }),
+  vectorSearchOrders: (query: string, limit?: number) =>
+    apiClient.get<VectorSearchResponse>('/api/search/vector/orders', {
+      params: { q: query, limit: limit || 3 },
     }),
 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -639,6 +639,18 @@ export const metricsApi = {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type OpenSearchResponse = Record<string, any>
 
+export type VectorLineItem = {
+  product_name?: string;
+  category?: string;
+  quantity?: number;
+  unit_price?: number;
+  live_price?: number;
+  base_price?: number;
+  price_change?: number;
+  line_amount?: number;
+  perishable_flag?: boolean;
+}
+
 export type VectorSearchResult = {
   order_id: string;
   score: number;
@@ -651,6 +663,7 @@ export type VectorSearchResult = {
   store_zone?: string;
   order_total_amount?: number;
   effective_updated_at?: string;
+  line_items?: VectorLineItem[];
 }
 
 export type VectorSearchResponse = {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -389,6 +389,12 @@ export interface TripleWriteRequest {
   object_value: string
 }
 
+export interface WriteTripleResponse {
+  status: string
+  timestamp: string
+  mz_timestamp_lower_bound: number | null
+}
+
 export interface ViewDefinitionResponse {
   view_name: string
   object_type: string
@@ -415,7 +421,7 @@ export const queryStatsApi = {
   getOrderData: () =>
     apiClient.get<OrderDataResponse>('/api/query-stats/order-data'),
   writeTriple: (data: TripleWriteRequest) =>
-    apiClient.post('/api/query-stats/write-triple', data),
+    apiClient.post<WriteTripleResponse>('/api/query-stats/write-triple', data),
   // Get view definition from Materialize
   getViewDefinition: (viewName: string) =>
     apiClient.get<ViewDefinitionResponse>(`/api/query-stats/view-definition/${encodeURIComponent(viewName)}`),
@@ -683,5 +689,9 @@ export const searchApi = {
   vectorSearchOrders: (query: string, limit?: number) =>
     apiClient.get<VectorSearchResponse>('/api/search/vector/orders', {
       params: { q: query, limit: limit || 3 },
+    }),
+  indexImpact: (since_mz_timestamp: number) =>
+    apiClient.get<{ impacted: number; total: number; pct: number }>('/api/search/impact', {
+      params: { since_mz_timestamp },
     }),
 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -640,6 +640,7 @@ export const metricsApi = {
 export type OpenSearchResponse = Record<string, any>
 
 export type VectorLineItem = {
+  line_id?: string;
   product_name?: string;
   category?: string;
   quantity?: number;

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -654,6 +654,7 @@ export type VectorLineItem = {
 export type VectorSearchResult = {
   order_id: string;
   score: number;
+  embedding: number[];
   embedding_text: string;
   embedded_at: string | null;
   order_number?: string;

--- a/web/src/components/LineageGraph.tsx
+++ b/web/src/components/LineageGraph.tsx
@@ -392,7 +392,10 @@ const nodeDefinitions: Array<{
   medallionLayer: MedallionLayer;
   highlighted?: boolean;
 }> = [
-  { id: 'triples', label: 'OLTP', type: 'source', medallionLayer: 'sources' },
+  { id: 'triples',        label: 'OLTP',              type: 'source', medallionLayer: 'sources' },
+  { id: 'src_customers',  label: 'Customers DB',       type: 'source', medallionLayer: 'sources' },
+  { id: 'src_operations', label: 'Operations DB',      type: 'source', medallionLayer: 'sources' },
+  { id: 'src_courier',    label: 'Courier Stream',     type: 'source', medallionLayer: 'sources' },
   { id: 'customers_flat', label: 'customers_flat', type: 'view', medallionLayer: 'bronze' },
   { id: 'stores_flat', label: 'stores_flat', type: 'view', medallionLayer: 'bronze' },
   { id: 'products_flat', label: 'products_flat', type: 'view', medallionLayer: 'bronze' },
@@ -463,12 +466,39 @@ function getLayoutedElements(
   const isPostgres = scenario === 'postgres';
   const isBatch = scenario === 'batch';
 
-  // In Postgres mode, triples lives in the Bronze column (no separate CDC source lane)
-  const effectiveNodeDefs = nodeDefs.map((n) =>
-    n.id === 'triples' && isPostgres
-      ? { ...n, label: 'triples', medallionLayer: 'bronze' as MedallionLayer }
-      : n
-  );
+  // Map triples → X edges to the correct named source in materialize/batch mode
+  const tripleSourceMap: Record<string, string> = {
+    customers_flat:    'src_customers',
+    stores_flat:       'src_operations',
+    products_flat:     'src_operations',
+    order_lines_base:  'src_operations',
+    orders_flat_mv:    'src_operations',
+    store_inventory_mv:'src_operations',
+    delivery_tasks_flat:'src_courier',
+  };
+
+  // In Postgres mode: triples moves to Bronze; src_* nodes hidden.
+  // In Materialize/Batch: triples hidden; src_* nodes shown; edges remapped.
+  const effectiveNodeDefs = nodeDefs
+    .filter((n) => {
+      if (n.id === 'triples') return true; // always keep; visibility handled below
+      if (['src_customers', 'src_operations', 'src_courier'].includes(n.id)) return !isPostgres;
+      return true;
+    })
+    .map((n) => {
+      if (n.id === 'triples' && isPostgres)
+        return { ...n, label: 'triples', medallionLayer: 'bronze' as MedallionLayer };
+      return n;
+    })
+    .filter((n) => !(n.id === 'triples' && !isPostgres));
+
+  const effectiveEdgeDefs = isPostgres
+    ? edgeDefs
+    : edgeDefs.map((e) =>
+        e.source === 'triples'
+          ? { ...e, source: tripleSourceMap[e.target] ?? e.source }
+          : e
+      );
 
   const dagreGraph = new dagre.graphlib.Graph();
   dagreGraph.setDefaultEdgeLabel(() => ({}));
@@ -478,13 +508,32 @@ function getLayoutedElements(
   effectiveNodeDefs.forEach((node) => {
     dagreGraph.setNode(node.id, { width: NODE_WIDTH, height: NODE_HEIGHT });
   });
-  edgeDefs.forEach((edge) => {
+  effectiveEdgeDefs.forEach((edge) => {
     dagreGraph.setEdge(edge.source, edge.target);
   });
   dagreGraph.setNode('source_systems_box', { width: SS_W, height: SS_H });
-  dagreGraph.setEdge('source_systems_box', 'triples');
+  // Anchor source_systems_box to source nodes so they all end up at the same dagre rank
+  if (isPostgres) {
+    dagreGraph.setEdge('source_systems_box', 'triples');
+  } else {
+    dagreGraph.setEdge('source_systems_box', 'src_customers');
+    dagreGraph.setEdge('source_systems_box', 'src_operations');
+    dagreGraph.setEdge('source_systems_box', 'src_courier');
+  }
 
   dagre.layout(dagreGraph);
+
+  // Force all three source nodes into the same x column and desired top-to-bottom order:
+  // Customers DB, Operations DB, Courier Stream
+  if (!isPostgres) {
+    const orderedSourceIds = ['src_customers', 'src_operations', 'src_courier'];
+    const minX = Math.min(...orderedSourceIds.map(id => dagreGraph.node(id).x));
+    const ys = orderedSourceIds.map(id => dagreGraph.node(id).y).sort((a, b) => a - b);
+    orderedSourceIds.forEach((id, i) => {
+      const n = dagreGraph.node(id);
+      dagreGraph.setNode(id, { ...n, x: minX, y: ys[i] });
+    });
+  }
 
   // Compute bounding boxes per medallion layer and overall graph
   const layerBounds: Record<MedallionLayer, { minX: number; maxX: number }> = {
@@ -648,10 +697,10 @@ function getLayoutedElements(
   });
 
   // Lineage edges
-  const edges: Edge[] = edgeDefs.map((edgeDef, index) => {
-    // In batch mode, edges from OLTP (triples) point forward toward their targets;
-    // all other non-materialize edges point backward (arrowhead at source end).
-    const batchForward = isBatch && edgeDef.source === 'triples';
+  const srcNodeIds = new Set(['triples', 'src_customers', 'src_operations', 'src_courier']);
+  const edges: Edge[] = effectiveEdgeDefs.map((edgeDef, index) => {
+    // In batch mode, edges from source nodes point forward; all others point backward.
+    const batchForward = isBatch && srcNodeIds.has(edgeDef.source);
     return {
       id: `e-${edgeDef.source}-${edgeDef.target}-${index}`,
       source: edgeDef.source,
@@ -673,13 +722,32 @@ function getLayoutedElements(
     {
       id: 'e-src-triples',
       source: 'source_systems_box',
-      target: 'triples',
+      target: isPostgres ? 'triples' : 'src_operations',
       sourceHandle: 'right',
       style: edgeStyle,
-      animated: isMaterialize,
-      markerEnd: isMaterialize ? undefined : { type: MarkerType.ArrowClosed, color: '#94a3b8' },
+      animated: true,
       zIndex: 1,
     },
+    ...(!isPostgres ? [
+      {
+        id: 'e-src-customers',
+        source: 'source_systems_box',
+        target: 'src_customers',
+        sourceHandle: 'right',
+        style: edgeStyle,
+        animated: true,
+        zIndex: 1,
+      },
+      {
+        id: 'e-src-courier',
+        source: 'source_systems_box',
+        target: 'src_courier',
+        sourceHandle: 'right',
+        style: edgeStyle,
+        animated: true,
+        zIndex: 1,
+      },
+    ] : []),
     {
       id: 'e-agent-mcp',
       source: '__agent__',

--- a/web/src/components/LineageGraph.tsx
+++ b/web/src/components/LineageGraph.tsx
@@ -21,6 +21,7 @@ const nodeColors = {
   view: { bg: '#6b7280', border: '#374151', text: '#ffffff' },
   mv: { bg: '#10b981', border: '#059669', text: '#ffffff' },
   index: { bg: '#8b5cf6', border: '#6d28d9', text: '#ffffff' },
+  tables: { bg: '#0891b2', border: '#0e7490', text: '#ffffff' },
 };
 
 // Medallion layer colors
@@ -120,7 +121,7 @@ const FgacBandNode = () => (
       }}
     >
       <span style={{ fontSize: '13px', fontWeight: 700, color: '#7c3aed' }}>
-        Fine-grained access control
+        Incremental View Maintenance via Timely Dataflow
       </span>
     </div>
     {/* Materialize branding at bottom */}
@@ -147,6 +148,60 @@ const FgacBandNode = () => (
   </div>
 );
 
+// OLAP wrapper band — Batch scenario: covers Sources + Bronze + Silver + Gold
+const OlapBandNode = () => (
+  <div
+    style={{
+      width: '100%',
+      height: '100%',
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'space-between',
+      padding: '10px',
+      boxSizing: 'border-box',
+      userSelect: 'none',
+      pointerEvents: 'none',
+    }}
+  >
+    {/* Header rectangle at top */}
+    <div
+      style={{
+        background: 'rgba(217, 119, 6, 0.12)',
+        border: '1px solid rgba(217, 119, 6, 0.45)',
+        borderRadius: '6px',
+        padding: '6px 14px',
+        textAlign: 'center',
+        flexShrink: 0,
+      }}
+    >
+      <span style={{ fontSize: '13px', fontWeight: 700, color: '#92400e' }}>
+        Scheduled Refresh
+      </span>
+    </div>
+    {/* OLAP branding at bottom */}
+    <div style={{ textAlign: 'center', paddingBottom: '2px' }}>
+      <span
+        style={{
+          fontSize: '13px',
+          fontWeight: 700,
+          color: '#d97706',
+          opacity: 0.5,
+          letterSpacing: '0.08em',
+          textTransform: 'uppercase',
+        }}
+      >
+        OLAP
+      </span>
+    </div>
+    <Handle
+      type="target"
+      position={Position.Top}
+      id="top"
+      style={{ pointerEvents: 'all', opacity: 0 }}
+    />
+  </div>
+);
+
 // Source wrapper band — Postgres scenario: covers Bronze + Silver + Gold
 const SourceWrapperBandNode = () => (
   <div
@@ -155,14 +210,29 @@ const SourceWrapperBandNode = () => (
       height: '100%',
       display: 'flex',
       flexDirection: 'column',
-      justifyContent: 'flex-end',
+      justifyContent: 'space-between',
       padding: '10px',
       boxSizing: 'border-box',
       userSelect: 'none',
       pointerEvents: 'none',
     }}
   >
-    {/* PostgreSQL branding at bottom only */}
+    {/* Header rectangle at top */}
+    <div
+      style={{
+        background: 'rgba(30, 64, 175, 0.10)',
+        border: '1px solid rgba(30, 64, 175, 0.40)',
+        borderRadius: '6px',
+        padding: '6px 14px',
+        textAlign: 'center',
+        flexShrink: 0,
+      }}
+    >
+      <span style={{ fontSize: '13px', fontWeight: 700, color: '#1e40af' }}>
+        Reactive query processing
+      </span>
+    </div>
+    {/* PostgreSQL branding at bottom */}
     <div style={{ textAlign: 'center', paddingBottom: '2px' }}>
       <span
         style={{
@@ -174,7 +244,7 @@ const SourceWrapperBandNode = () => (
           textTransform: 'uppercase',
         }}
       >
-        PostgreSQL
+        OLTP
       </span>
     </div>
     <Handle
@@ -292,6 +362,7 @@ const McpNode = () => (
 const nodeTypes: NodeTypes = {
   band: BandNode,
   fgac_band: FgacBandNode,
+  olap_band: OlapBandNode,
   source_wrapper_band: SourceWrapperBandNode,
   source_systems_node: SourceSystemsNode,
   agent_node: AgentNode,
@@ -386,13 +457,15 @@ function getLayoutedElements(
   nodeDefs: typeof nodeDefinitions,
   edgeDefs: typeof edgeDefinitions,
   selectedNodeId: string | null | undefined,
-  scenario: 'materialize' | 'postgres' = 'materialize'
+  scenario: 'materialize' | 'postgres' | 'batch' = 'materialize'
 ): { nodes: Node[]; edges: Edge[] } {
   const isMaterialize = scenario === 'materialize';
+  const isPostgres = scenario === 'postgres';
+  const isBatch = scenario === 'batch';
 
   // In Postgres mode, triples lives in the Bronze column (no separate CDC source lane)
   const effectiveNodeDefs = nodeDefs.map((n) =>
-    n.id === 'triples' && !isMaterialize
+    n.id === 'triples' && isPostgres
       ? { ...n, label: 'triples', medallionLayer: 'bronze' as MedallionLayer }
       : n
   );
@@ -472,21 +545,29 @@ function getLayoutedElements(
   const wrapperMinX = Math.min(layerBounds.bronze.minX, layerBounds.silver.minX, layerBounds.gold.minX);
   const wrapperMaxX = Math.max(layerBounds.bronze.maxX, layerBounds.silver.maxX, layerBounds.gold.maxX);
   const wrapperLeft = wrapperMinX - BAND_PADDING_X - FGAC_PAD;
-  // Materialize needs extra top room for the FGAC header rectangle; Postgres just needs padding
-  const wrapperLabelTop = isMaterialize ? FGAC_LABEL_TOP : FGAC_PAD;
+  // All scenarios have a header rectangle, so all need the same top clearance
+  const wrapperLabelTop = FGAC_LABEL_TOP;
   const wrapperTop = graphMinY - BAND_PADDING_Y - wrapperLabelTop - FGAC_PAD;
   const wrapperWidth = wrapperMaxX - wrapperMinX + (BAND_PADDING_X + FGAC_PAD) * 2;
   const wrapperHeight = graphMaxY - graphMinY + (BAND_PADDING_Y + FGAC_PAD) * 2 + wrapperLabelTop + FGAC_LABEL_BOTTOM;
 
   const outerBandNode: Node = {
-    id: isMaterialize ? '__fgac__' : '__source_wrapper__',
-    type: isMaterialize ? 'fgac_band' : 'source_wrapper_band',
+    id: isMaterialize ? '__fgac__' : isBatch ? '__olap__' : '__source_wrapper__',
+    type: isMaterialize ? 'fgac_band' : isBatch ? 'olap_band' : 'source_wrapper_band',
     position: { x: wrapperLeft, y: wrapperTop },
     style: {
       width: wrapperWidth,
       height: wrapperHeight,
-      background: isMaterialize ? 'rgba(124, 58, 237, 0.04)' : 'rgba(30, 64, 175, 0.04)',
-      border: isMaterialize ? '1.5px solid rgba(124, 58, 237, 0.35)' : '1.5px solid rgba(30, 64, 175, 0.30)',
+      background: isMaterialize
+        ? 'rgba(124, 58, 237, 0.04)'
+        : isBatch
+          ? 'rgba(217, 119, 6, 0.04)'
+          : 'rgba(30, 64, 175, 0.04)',
+      border: isMaterialize
+        ? '1.5px solid rgba(124, 58, 237, 0.35)'
+        : isBatch
+          ? '1.5px solid rgba(217, 119, 6, 0.30)'
+          : '1.5px solid rgba(30, 64, 175, 0.30)',
       borderRadius: '12px',
     },
     data: { label: '' },
@@ -544,9 +625,14 @@ function getLayoutedElements(
     const isSelected = nodeDef.id === selectedNodeId;
     const isHighlighted = nodeDef.highlighted || false;
 
-    const effectiveType = !isMaterialize && nodeDef.type === 'mv' ? 'view' : nodeDef.type;
+    // Postgres: MVs → view color, triples → tables color; Materialize/Batch keep originals
+    const effectiveType = isPostgres && nodeDef.type === 'mv'
+      ? 'view'
+      : isPostgres && nodeDef.id === 'triples'
+        ? 'tables'
+        : nodeDef.type;
     let style = getNodeStyle(effectiveType, isSelected);
-    if (isHighlighted && !isSelected && isMaterialize) {
+    if (isHighlighted && !isSelected && !isPostgres) {
       style = { ...style, border: '3px solid #059669', boxShadow: '0 0 10px rgba(16, 185, 129, 0.4)' };
     }
 
@@ -562,15 +648,25 @@ function getLayoutedElements(
   });
 
   // Lineage edges
-  const edges: Edge[] = edgeDefs.map((edgeDef, index) => ({
-    id: `e-${edgeDef.source}-${edgeDef.target}-${index}`,
-    source: edgeDef.source,
-    target: edgeDef.target,
-    style: edgeStyle,
-    animated: isMaterialize,
-    markerStart: isMaterialize ? undefined : { type: MarkerType.ArrowClosed, color: '#94a3b8', orient: 'auto-start-reverse' },
-    zIndex: 1,
-  }));
+  const edges: Edge[] = edgeDefs.map((edgeDef, index) => {
+    // In batch mode, edges from OLTP (triples) point forward toward their targets;
+    // all other non-materialize edges point backward (arrowhead at source end).
+    const batchForward = isBatch && edgeDef.source === 'triples';
+    return {
+      id: `e-${edgeDef.source}-${edgeDef.target}-${index}`,
+      source: edgeDef.source,
+      target: edgeDef.target,
+      style: edgeStyle,
+      animated: isMaterialize,
+      markerStart: (!isMaterialize && !batchForward)
+        ? { type: MarkerType.ArrowClosed, color: '#94a3b8', orient: 'auto-start-reverse' }
+        : undefined,
+      markerEnd: batchForward
+        ? { type: MarkerType.ArrowClosed, color: '#94a3b8' }
+        : undefined,
+      zIndex: 1,
+    };
+  });
 
   // Overlay edges: source systems data flow + agent/MCP interactions
   const overlayEdges: Edge[] = [
@@ -581,7 +677,7 @@ function getLayoutedElements(
       sourceHandle: 'right',
       style: edgeStyle,
       animated: isMaterialize,
-      markerStart: isMaterialize ? undefined : { type: MarkerType.ArrowClosed, color: '#94a3b8', orient: 'auto-start-reverse' },
+      markerEnd: isMaterialize ? undefined : { type: MarkerType.ArrowClosed, color: '#94a3b8' },
       zIndex: 1,
     },
     {
@@ -613,11 +709,11 @@ function getLayoutedElements(
     {
       id: 'e-mcp-wrapper',
       source: '__mcp__',
-      target: isMaterialize ? '__fgac__' : '__source_wrapper__',
+      target: isMaterialize ? '__fgac__' : isBatch ? '__olap__' : '__source_wrapper__',
       sourceHandle: 'bottom',
       targetHandle: 'top',
       style: {
-        stroke: isMaterialize ? '#a855f7' : '#1e40af',
+        stroke: isMaterialize ? '#a855f7' : isBatch ? '#d97706' : '#1e40af',
         strokeWidth: 1.5,
         strokeDasharray: '5,3',
       },
@@ -635,7 +731,7 @@ function getLayoutedElements(
 interface LineageGraphProps {
   selectedNodeId?: string | null;
   onNodeClick?: (nodeId: string) => void;
-  scenario?: 'materialize' | 'postgres';
+  scenario?: 'materialize' | 'postgres' | 'batch';
 }
 
 export function LineageGraph({ selectedNodeId, onNodeClick, scenario = 'materialize' }: LineageGraphProps) {
@@ -691,6 +787,10 @@ export function LineageGraph({ selectedNodeId, onNodeClick, scenario = 'material
         <div className="flex items-center gap-2">
           <div className="w-4 h-4 rounded" style={{ background: nodeColors.mv.bg }} />
           <span className="text-gray-600">Materialized View</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="w-4 h-4 rounded" style={{ background: nodeColors.tables.bg }} />
+          <span className="text-gray-600">Table</span>
         </div>
 
         {selectedNodeId && (

--- a/web/src/components/LineageGraph.tsx
+++ b/web/src/components/LineageGraph.tsx
@@ -5,20 +5,21 @@ import {
   Edge,
   Background,
   Position,
+  Handle,
   NodeMouseHandler,
   NodeTypes,
 } from '@xyflow/react';
 import dagre from 'dagre';
 import '@xyflow/react/dist/style.css';
 
-type MedallionLayer = 'sources' | 'bronze' | 'silver' | 'gold';
+type MedallionLayer = 'source_systems' | 'sources' | 'bronze' | 'silver' | 'gold';
 
 // Node type colors (object type)
 const nodeColors = {
-  source: { bg: '#3b82f6', border: '#1d4ed8', text: '#ffffff' }, // Blue
-  view: { bg: '#6b7280', border: '#374151', text: '#ffffff' }, // Gray
-  mv: { bg: '#10b981', border: '#059669', text: '#ffffff' }, // Green
-  index: { bg: '#8b5cf6', border: '#6d28d9', text: '#ffffff' }, // Purple
+  source: { bg: '#3b82f6', border: '#1d4ed8', text: '#ffffff' },
+  view: { bg: '#6b7280', border: '#374151', text: '#ffffff' },
+  mv: { bg: '#10b981', border: '#059669', text: '#ffffff' },
+  index: { bg: '#8b5cf6', border: '#6d28d9', text: '#ffffff' },
 };
 
 // Medallion layer colors
@@ -26,40 +27,41 @@ const medallionColors: Record<MedallionLayer, {
   bg: string;
   border: string;
   labelColor: string;
-  legendDot: string;
   legendLabel: string;
 }> = {
+  source_systems: {
+    bg: 'rgba(148, 163, 184, 0.07)',
+    border: 'rgba(148, 163, 184, 0.30)',
+    labelColor: '#475569',
+    legendLabel: 'Source Systems',
+  },
   sources: {
     bg: 'rgba(59, 130, 246, 0.07)',
     border: 'rgba(59, 130, 246, 0.28)',
     labelColor: '#1d4ed8',
-    legendDot: '#3b82f6',
     legendLabel: 'Sources',
   },
   bronze: {
     bg: 'rgba(180, 83, 9, 0.07)',
     border: 'rgba(180, 83, 9, 0.28)',
     labelColor: '#92400e',
-    legendDot: '#b45309',
     legendLabel: 'Bronze',
   },
   silver: {
     bg: 'rgba(100, 116, 139, 0.07)',
     border: 'rgba(100, 116, 139, 0.28)',
     labelColor: '#475569',
-    legendDot: '#64748b',
     legendLabel: 'Silver',
   },
   gold: {
     bg: 'rgba(234, 179, 8, 0.09)',
     border: 'rgba(234, 179, 8, 0.5)',
     labelColor: '#854d0e',
-    legendDot: '#d97706',
     legendLabel: 'Gold',
   },
 };
 
-// Custom band node rendered behind the graph nodes
+// Swim-lane label band
 const BandNode = ({ data }: { data: { layer: MedallionLayer } }) => {
   const colors = medallionColors[data.layer];
   return (
@@ -90,9 +92,152 @@ const BandNode = ({ data }: { data: { layer: MedallionLayer } }) => {
   );
 };
 
-const nodeTypes: NodeTypes = { band: BandNode };
+// Fine-grained access control wrapper (behind bronze/silver/gold bands)
+const FgacBandNode = () => (
+  <div
+    style={{
+      width: '100%',
+      height: '100%',
+      display: 'flex',
+      alignItems: 'flex-start',
+      justifyContent: 'center',
+      paddingTop: '8px',
+      userSelect: 'none',
+      pointerEvents: 'none',
+    }}
+  >
+    <span
+      style={{
+        fontSize: '10px',
+        fontWeight: 700,
+        letterSpacing: '0.06em',
+        color: '#7c3aed',
+        opacity: 0.85,
+      }}
+    >
+      Fine-grained access control
+    </span>
+    <Handle
+      type="target"
+      position={Position.Top}
+      id="top"
+      style={{ pointerEvents: 'all', opacity: 0 }}
+    />
+  </div>
+);
 
-// Custom node styles
+// Source Systems column node (CRM / ERP / Apps / External Data)
+const SourceSystemsNode = () => (
+  <div
+    style={{
+      width: '100%',
+      height: '100%',
+      background: '#f8fafc',
+      border: '1.5px solid #94a3b8',
+      borderRadius: '10px',
+      padding: '8px 10px',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '5px',
+      boxSizing: 'border-box',
+      userSelect: 'none',
+    }}
+  >
+    <Handle type="target" position={Position.Top} id="top" style={{ opacity: 0 }} />
+    <div
+      style={{
+        fontSize: '10px',
+        fontWeight: 700,
+        color: '#374151',
+        textAlign: 'center',
+        borderBottom: '1px solid #e5e7eb',
+        paddingBottom: '4px',
+        marginBottom: '2px',
+      }}
+    >
+      Source Systems
+    </div>
+    {['CRM', 'ERP', 'Apps', 'External Data'].map((s) => (
+      <div
+        key={s}
+        style={{
+          fontSize: '10px',
+          color: '#475569',
+          background: '#f1f5f9',
+          border: '1px solid #e2e8f0',
+          borderRadius: '4px',
+          padding: '2px 6px',
+          textAlign: 'center',
+        }}
+      >
+        {s}
+      </div>
+    ))}
+    <Handle type="source" position={Position.Right} id="right" style={{ opacity: 0 }} />
+  </div>
+);
+
+// Agent node
+const AgentNode = () => (
+  <div
+    style={{
+      width: '100%',
+      height: '100%',
+      background: '#fff7ed',
+      border: '2px solid #f97316',
+      borderRadius: '10px',
+      padding: '8px 12px',
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: '3px',
+      boxSizing: 'border-box',
+      userSelect: 'none',
+    }}
+  >
+    <span style={{ fontSize: '20px', lineHeight: 1 }}>🤖</span>
+    <span style={{ fontSize: '11px', fontWeight: 700, color: '#9a3412' }}>Agent</span>
+    <Handle type="source" position={Position.Right} id="right" style={{ opacity: 0 }} />
+    <Handle type="source" position={Position.Bottom} id="bottom" style={{ opacity: 0 }} />
+  </div>
+);
+
+// MCP Server node
+const McpNode = () => (
+  <div
+    style={{
+      width: '100%',
+      height: '100%',
+      background: '#fdf4ff',
+      border: '2px solid #a855f7',
+      borderRadius: '10px',
+      padding: '8px 12px',
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: '2px',
+      boxSizing: 'border-box',
+      userSelect: 'none',
+    }}
+  >
+    <span style={{ fontSize: '16px', lineHeight: 1 }}>⚙️</span>
+    <span style={{ fontSize: '11px', fontWeight: 700, color: '#7e22ce' }}>MCP Server</span>
+    <Handle type="target" position={Position.Left} id="left" style={{ opacity: 0 }} />
+    <Handle type="source" position={Position.Bottom} id="bottom" style={{ opacity: 0 }} />
+  </div>
+);
+
+const nodeTypes: NodeTypes = {
+  band: BandNode,
+  fgac_band: FgacBandNode,
+  source_systems_node: SourceSystemsNode,
+  agent_node: AgentNode,
+  mcp_node: McpNode,
+};
+
+// Custom node styles for lineage nodes
 const getNodeStyle = (type: keyof typeof nodeColors, isSelected: boolean = false) => ({
   background: nodeColors[type].bg,
   border: `2px solid ${isSelected ? '#fbbf24' : nodeColors[type].border}`,
@@ -107,8 +252,7 @@ const getNodeStyle = (type: keyof typeof nodeColors, isSelected: boolean = false
   boxShadow: isSelected ? '0 0 12px rgba(251, 191, 36, 0.6)' : undefined,
 });
 
-// Node definitions (without positions - dagre will compute them)
-// Based on actual Materialize dependencies from mz_internal.mz_object_dependencies
+// Lineage node definitions (positions computed by dagre)
 const nodeDefinitions: Array<{
   id: string;
   label: string;
@@ -130,52 +274,52 @@ const nodeDefinitions: Array<{
   { id: 'inventory_items_with_dynamic_pricing_mv', label: 'dynamic_pricing_mv', type: 'mv', highlighted: true, medallionLayer: 'gold' },
 ];
 
-// Edge definitions based on actual Materialize dependencies
+// Lineage edge definitions
 const edgeDefinitions = [
-  // Tier 0 → Tier 1: triples to base views
   { source: 'triples', target: 'customers_flat' },
   { source: 'triples', target: 'stores_flat' },
   { source: 'triples', target: 'products_flat' },
   { source: 'triples', target: 'order_lines_base' },
   { source: 'triples', target: 'delivery_tasks_flat' },
-  // Tier 0 → Tier 2: triples directly to orders_flat_mv
   { source: 'triples', target: 'orders_flat_mv' },
-  // Tier 1 → Tier 2: base views to order_lines_flat_mv
   { source: 'order_lines_base', target: 'order_lines_flat_mv' },
   { source: 'products_flat', target: 'order_lines_flat_mv' },
-  // Tier 1,2 → Tier 3: to store_inventory_mv
   { source: 'triples', target: 'store_inventory_mv' },
   { source: 'products_flat', target: 'store_inventory_mv' },
   { source: 'stores_flat', target: 'store_inventory_mv' },
   { source: 'orders_flat_mv', target: 'store_inventory_mv' },
   { source: 'order_lines_flat_mv', target: 'store_inventory_mv' },
-  // Tier 1,2 → Tier 4: to orders_with_lines_mv
   { source: 'customers_flat', target: 'orders_with_lines_mv' },
   { source: 'stores_flat', target: 'orders_with_lines_mv' },
   { source: 'delivery_tasks_flat', target: 'orders_with_lines_mv' },
   { source: 'orders_flat_mv', target: 'orders_with_lines_mv' },
   { source: 'order_lines_flat_mv', target: 'orders_with_lines_mv' },
-  // Tier 2,3 → Tier 4: to dynamic_pricing
   { source: 'store_inventory_mv', target: 'inventory_items_with_dynamic_pricing' },
   { source: 'orders_flat_mv', target: 'inventory_items_with_dynamic_pricing' },
   { source: 'order_lines_flat_mv', target: 'inventory_items_with_dynamic_pricing' },
-  // Tier 4 → Tier 5: dynamic_pricing to dynamic_pricing_mv
   { source: 'inventory_items_with_dynamic_pricing', target: 'inventory_items_with_dynamic_pricing_mv' },
 ];
 
-// Edge style
-const edgeStyle = {
-  stroke: '#94a3b8',
-  strokeWidth: 2,
-};
+const edgeStyle = { stroke: '#94a3b8', strokeWidth: 2 };
 
 // Node dimensions for dagre layout
 const NODE_WIDTH = 150;
 const NODE_HEIGHT = 40;
 const BAND_PADDING_X = 18;
 const BAND_PADDING_Y = 28;
+// Source Systems box (taller to accommodate 4 items)
+const SS_W = 130;
+const SS_H = 118;
+// Floating nodes above the graph
+const AGENT_W = 88;
+const AGENT_H = 64;
+const MCP_W = 104;
+const MCP_H = 64;
+// FGAC wrapper extra space
+const FGAC_LABEL_TOP = 24;
+const FGAC_PAD = 10;
+const FLOAT_GAP = 28;
 
-// Use dagre to compute node positions, then build swim-lane band nodes
 function getLayoutedElements(
   nodeDefs: typeof nodeDefinitions,
   edgeDefs: typeof edgeDefinitions,
@@ -183,28 +327,23 @@ function getLayoutedElements(
 ): { nodes: Node[]; edges: Edge[] } {
   const dagreGraph = new dagre.graphlib.Graph();
   dagreGraph.setDefaultEdgeLabel(() => ({}));
+  dagreGraph.setGraph({ rankdir: 'LR', nodesep: 50, ranksep: 100, marginx: 20, marginy: 20 });
 
-  // Configure dagre for left-to-right layout with good spacing
-  dagreGraph.setGraph({
-    rankdir: 'LR',
-    nodesep: 50,
-    ranksep: 100,
-    marginx: 20,
-    marginy: 20,
-  });
-
+  // Add lineage nodes + source_systems_box to dagre for layout
   nodeDefs.forEach((node) => {
     dagreGraph.setNode(node.id, { width: NODE_WIDTH, height: NODE_HEIGHT });
   });
-
   edgeDefs.forEach((edge) => {
     dagreGraph.setEdge(edge.source, edge.target);
   });
+  dagreGraph.setNode('source_systems_box', { width: SS_W, height: SS_H });
+  dagreGraph.setEdge('source_systems_box', 'triples');
 
   dagre.layout(dagreGraph);
 
   // Compute bounding boxes per medallion layer and overall graph
   const layerBounds: Record<MedallionLayer, { minX: number; maxX: number }> = {
+    source_systems: { minX: Infinity, maxX: -Infinity },
     sources: { minX: Infinity, maxX: -Infinity },
     bronze: { minX: Infinity, maxX: -Infinity },
     silver: { minX: Infinity, maxX: -Infinity },
@@ -215,70 +354,128 @@ function getLayoutedElements(
 
   nodeDefs.forEach((nodeDef) => {
     const pos = dagreGraph.node(nodeDef.id);
-    const leftEdge = pos.x - NODE_WIDTH / 2;
-    const rightEdge = pos.x + NODE_WIDTH / 2;
-    const topEdge = pos.y - NODE_HEIGHT / 2;
-    const bottomEdge = pos.y + NODE_HEIGHT / 2;
-
-    graphMinY = Math.min(graphMinY, topEdge);
-    graphMaxY = Math.max(graphMaxY, bottomEdge);
-
-    const bounds = layerBounds[nodeDef.medallionLayer];
-    bounds.minX = Math.min(bounds.minX, leftEdge);
-    bounds.maxX = Math.max(bounds.maxX, rightEdge);
+    graphMinY = Math.min(graphMinY, pos.y - NODE_HEIGHT / 2);
+    graphMaxY = Math.max(graphMaxY, pos.y + NODE_HEIGHT / 2);
+    const b = layerBounds[nodeDef.medallionLayer];
+    b.minX = Math.min(b.minX, pos.x - NODE_WIDTH / 2);
+    b.maxX = Math.max(b.maxX, pos.x + NODE_WIDTH / 2);
   });
 
-  // Create swim-lane band nodes (rendered behind via zIndex: -1)
+  // Include source_systems_box in graph + layer bounds
+  const ssPos = dagreGraph.node('source_systems_box');
+  graphMinY = Math.min(graphMinY, ssPos.y - SS_H / 2);
+  graphMaxY = Math.max(graphMaxY, ssPos.y + SS_H / 2);
+  layerBounds.source_systems.minX = ssPos.x - SS_W / 2;
+  layerBounds.source_systems.maxX = ssPos.x + SS_W / 2;
+
+  // Swim-lane band nodes for each layer
   const bandNodes: Node[] = (Object.keys(layerBounds) as MedallionLayer[])
-    .filter((layer) => layerBounds[layer].minX !== Infinity) // skip empty layers to avoid NaN dimensions
+    .filter((layer) => layerBounds[layer].minX !== Infinity)
     .map((layer) => {
-    const bounds = layerBounds[layer];
-    const colors = medallionColors[layer];
-    return {
-      id: `__band__${layer}`,
-      type: 'band',
-      position: {
-        x: bounds.minX - BAND_PADDING_X,
-        y: graphMinY - BAND_PADDING_Y,
-      },
-      style: {
-        width: bounds.maxX - bounds.minX + BAND_PADDING_X * 2,
-        height: graphMaxY - graphMinY + BAND_PADDING_Y * 2,
-        background: colors.bg,
-        border: `1.5px solid ${colors.border}`,
-        borderRadius: '10px',
-        pointerEvents: 'none' as const,
-      },
-      data: { label: '', layer },
-      zIndex: -1,
-      selectable: false,
-      draggable: false,
-      focusable: false,
-    };
-  });
+      const b = layerBounds[layer];
+      const colors = medallionColors[layer];
+      return {
+        id: `__band__${layer}`,
+        type: 'band',
+        position: { x: b.minX - BAND_PADDING_X, y: graphMinY - BAND_PADDING_Y },
+        style: {
+          width: b.maxX - b.minX + BAND_PADDING_X * 2,
+          height: graphMaxY - graphMinY + BAND_PADDING_Y * 2,
+          background: colors.bg,
+          border: `1.5px solid ${colors.border}`,
+          borderRadius: '10px',
+          pointerEvents: 'none' as const,
+        },
+        data: { label: '', layer },
+        zIndex: -1,
+        selectable: false,
+        draggable: false,
+        focusable: false,
+      };
+    });
 
-  // Create React Flow nodes with computed positions
+  // FGAC wrapper band (behind bronze/silver/gold, with label above them)
+  const fgacMinX = Math.min(layerBounds.bronze.minX, layerBounds.silver.minX, layerBounds.gold.minX);
+  const fgacMaxX = Math.max(layerBounds.bronze.maxX, layerBounds.silver.maxX, layerBounds.gold.maxX);
+  const fgacLeft = fgacMinX - BAND_PADDING_X - FGAC_PAD;
+  const fgacTop = graphMinY - BAND_PADDING_Y - FGAC_LABEL_TOP - FGAC_PAD;
+  const fgacWidth = fgacMaxX - fgacMinX + (BAND_PADDING_X + FGAC_PAD) * 2;
+  const fgacHeight = graphMaxY - graphMinY + (BAND_PADDING_Y + FGAC_PAD) * 2 + FGAC_LABEL_TOP;
+
+  const fgacBandNode: Node = {
+    id: '__fgac__',
+    type: 'fgac_band',
+    position: { x: fgacLeft, y: fgacTop },
+    style: {
+      width: fgacWidth,
+      height: fgacHeight,
+      background: 'rgba(124, 58, 237, 0.04)',
+      border: '1.5px solid rgba(124, 58, 237, 0.35)',
+      borderRadius: '12px',
+    },
+    data: { label: '' },
+    zIndex: -2,
+    selectable: false,
+    draggable: false,
+    focusable: false,
+  };
+
+  // Floating Agent + MCP nodes above the graph
+  const floatY = fgacTop - FLOAT_GAP - AGENT_H;
+  const ssCenterX = (layerBounds.source_systems.minX + layerBounds.source_systems.maxX) / 2;
+  const fgacCenterX = fgacLeft + fgacWidth / 2;
+
+  const agentNode: Node = {
+    id: '__agent__',
+    type: 'agent_node',
+    position: { x: ssCenterX - AGENT_W / 2, y: floatY },
+    style: { width: AGENT_W, height: AGENT_H },
+    data: { label: 'Agent' },
+    zIndex: 2,
+    selectable: false,
+    draggable: false,
+    focusable: false,
+  };
+
+  const mcpNode: Node = {
+    id: '__mcp__',
+    type: 'mcp_node',
+    position: { x: fgacCenterX - MCP_W / 2, y: floatY },
+    style: { width: MCP_W, height: MCP_H },
+    data: { label: 'MCP Server' },
+    zIndex: 2,
+    selectable: false,
+    draggable: false,
+    focusable: false,
+  };
+
+  // Source Systems box node
+  const sourceSysNode: Node = {
+    id: 'source_systems_box',
+    type: 'source_systems_node',
+    position: { x: ssPos.x - SS_W / 2, y: ssPos.y - SS_H / 2 },
+    style: { width: SS_W, height: SS_H },
+    data: { label: '' },
+    zIndex: 1,
+    selectable: false,
+    draggable: false,
+    focusable: false,
+  };
+
+  // Lineage nodes
   const nodes: Node[] = nodeDefs.map((nodeDef) => {
-    const nodeWithPosition = dagreGraph.node(nodeDef.id);
+    const pos = dagreGraph.node(nodeDef.id);
     const isSelected = nodeDef.id === selectedNodeId;
     const isHighlighted = nodeDef.highlighted || false;
 
     let style = getNodeStyle(nodeDef.type, isSelected);
     if (isHighlighted && !isSelected) {
-      style = {
-        ...style,
-        border: '3px solid #059669',
-        boxShadow: '0 0 10px rgba(16, 185, 129, 0.4)',
-      };
+      style = { ...style, border: '3px solid #059669', boxShadow: '0 0 10px rgba(16, 185, 129, 0.4)' };
     }
 
     return {
       id: nodeDef.id,
-      position: {
-        // Dagre gives center position, React Flow uses top-left
-        x: nodeWithPosition.x - NODE_WIDTH / 2,
-        y: nodeWithPosition.y - NODE_HEIGHT / 2,
-      },
+      position: { x: pos.x - NODE_WIDTH / 2, y: pos.y - NODE_HEIGHT / 2 },
       data: { label: nodeDef.label },
       style,
       sourcePosition: Position.Right,
@@ -287,6 +484,7 @@ function getLayoutedElements(
     };
   });
 
+  // Lineage edges
   const edges: Edge[] = edgeDefs.map((edgeDef, index) => ({
     id: `e-${edgeDef.source}-${edgeDef.target}-${index}`,
     source: edgeDef.source,
@@ -296,7 +494,59 @@ function getLayoutedElements(
     zIndex: 1,
   }));
 
-  return { nodes: [...bandNodes, ...nodes], edges };
+  // Overlay edges: source systems data flow + agent/MCP interactions
+  const overlayEdges: Edge[] = [
+    {
+      id: 'e-src-triples',
+      source: 'source_systems_box',
+      target: 'triples',
+      sourceHandle: 'right',
+      style: edgeStyle,
+      animated: true,
+      zIndex: 1,
+    },
+    {
+      id: 'e-agent-mcp',
+      source: '__agent__',
+      target: '__mcp__',
+      sourceHandle: 'right',
+      targetHandle: 'left',
+      label: 'Observe',
+      style: { stroke: '#6b7280', strokeWidth: 1.5 },
+      labelStyle: { fontSize: '10px', fill: '#6b7280', fontWeight: 600 },
+      labelBgStyle: { fill: '#f9fafb', fillOpacity: 0.85 },
+      animated: false,
+      zIndex: 3,
+    },
+    {
+      id: 'e-agent-src',
+      source: '__agent__',
+      target: 'source_systems_box',
+      sourceHandle: 'bottom',
+      targetHandle: 'top',
+      label: 'Act',
+      style: { stroke: '#6b7280', strokeWidth: 1.5 },
+      labelStyle: { fontSize: '10px', fill: '#6b7280', fontWeight: 600 },
+      labelBgStyle: { fill: '#f9fafb', fillOpacity: 0.85 },
+      animated: false,
+      zIndex: 3,
+    },
+    {
+      id: 'e-mcp-fgac',
+      source: '__mcp__',
+      target: '__fgac__',
+      sourceHandle: 'bottom',
+      targetHandle: 'top',
+      style: { stroke: '#a855f7', strokeWidth: 1.5, strokeDasharray: '5,3' },
+      animated: false,
+      zIndex: 3,
+    },
+  ];
+
+  return {
+    nodes: [...bandNodes, fgacBandNode, agentNode, mcpNode, sourceSysNode, ...nodes],
+    edges: [...edges, ...overlayEdges],
+  };
 }
 
 interface LineageGraphProps {
@@ -312,8 +562,7 @@ export function LineageGraph({ selectedNodeId, onNodeClick }: LineageGraphProps)
 
   const handleNodeClick: NodeMouseHandler = useCallback(
     (_, node) => {
-      // Ignore clicks on band nodes
-      if (node.id.startsWith('__band__')) return;
+      if (node.id.startsWith('__') || node.id === 'source_systems_box') return;
       if (onNodeClick) {
         onNodeClick(node.id);
       }
@@ -324,14 +573,14 @@ export function LineageGraph({ selectedNodeId, onNodeClick }: LineageGraphProps)
   return (
     <div className="w-full">
       {/* Graph */}
-      <div className="h-[350px] w-full border border-gray-200 rounded-lg bg-gray-50">
+      <div className="h-[420px] w-full border border-gray-200 rounded-lg bg-gray-50">
         <ReactFlow
           nodes={nodes}
           edges={edges}
           nodeTypes={nodeTypes}
           onNodeClick={handleNodeClick}
           fitView
-          fitViewOptions={{ padding: 0.2 }}
+          fitViewOptions={{ padding: 0.15 }}
           nodesDraggable={false}
           nodesConnectable={false}
           elementsSelectable={true}
@@ -347,7 +596,6 @@ export function LineageGraph({ selectedNodeId, onNodeClick }: LineageGraphProps)
 
       {/* Legend */}
       <div className="flex flex-wrap gap-x-6 gap-y-2 mt-3 text-sm">
-        {/* Object type legend */}
         <div className="flex items-center gap-2">
           <div className="w-4 h-4 rounded" style={{ background: nodeColors.source.bg }} />
           <span className="text-gray-600">Source (CDC)</span>
@@ -375,7 +623,7 @@ export function LineageGraph({ selectedNodeId, onNodeClick }: LineageGraphProps)
         <span className="font-medium text-green-600">store_inventory_mv</span> (stock levels),{' '}
         <span className="font-medium text-green-600">orders_with_lines_mv</span> (order details), and{' '}
         <span className="font-medium text-green-600">dynamic_pricing_mv</span> (live pricing with 9 factors).
-        The API joins them at query time for a consistent snapshot. Click any node to view its SQL.
+        The agent observes via MCP and acts on source systems. Click any node to view its SQL.
       </p>
     </div>
   );

--- a/web/src/components/LineageGraph.tsx
+++ b/web/src/components/LineageGraph.tsx
@@ -6,6 +6,7 @@ import {
   Background,
   Position,
   Handle,
+  MarkerType,
   NodeMouseHandler,
   NodeTypes,
 } from '@xyflow/react';
@@ -146,6 +147,45 @@ const FgacBandNode = () => (
   </div>
 );
 
+// Source wrapper band — Postgres scenario: covers Bronze + Silver + Gold
+const SourceWrapperBandNode = () => (
+  <div
+    style={{
+      width: '100%',
+      height: '100%',
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'flex-end',
+      padding: '10px',
+      boxSizing: 'border-box',
+      userSelect: 'none',
+      pointerEvents: 'none',
+    }}
+  >
+    {/* PostgreSQL branding at bottom only */}
+    <div style={{ textAlign: 'center', paddingBottom: '2px' }}>
+      <span
+        style={{
+          fontSize: '13px',
+          fontWeight: 700,
+          color: '#1e40af',
+          opacity: 0.5,
+          letterSpacing: '0.08em',
+          textTransform: 'uppercase',
+        }}
+      >
+        PostgreSQL
+      </span>
+    </div>
+    <Handle
+      type="target"
+      position={Position.Top}
+      id="top"
+      style={{ pointerEvents: 'all', opacity: 0 }}
+    />
+  </div>
+);
+
 // Source Systems column node (CRM / ERP / Apps / External Data)
 const SourceSystemsNode = () => (
   <div
@@ -252,6 +292,7 @@ const McpNode = () => (
 const nodeTypes: NodeTypes = {
   band: BandNode,
   fgac_band: FgacBandNode,
+  source_wrapper_band: SourceWrapperBandNode,
   source_systems_node: SourceSystemsNode,
   agent_node: AgentNode,
   mcp_node: McpNode,
@@ -329,7 +370,7 @@ const BAND_PADDING_X = 20;
 const BAND_PADDING_Y = 32;
 // Source Systems box (taller to accommodate 4 items)
 const SS_W = 150;
-const SS_H = 136;
+const SS_H = 170;
 // Floating nodes above the graph
 const AGENT_W = 100;
 const AGENT_H = 76;
@@ -344,14 +385,24 @@ const FLOAT_GAP = 28;
 function getLayoutedElements(
   nodeDefs: typeof nodeDefinitions,
   edgeDefs: typeof edgeDefinitions,
-  selectedNodeId: string | null | undefined
+  selectedNodeId: string | null | undefined,
+  scenario: 'materialize' | 'postgres' = 'materialize'
 ): { nodes: Node[]; edges: Edge[] } {
+  const isMaterialize = scenario === 'materialize';
+
+  // In Postgres mode, triples lives in the Bronze column (no separate CDC source lane)
+  const effectiveNodeDefs = nodeDefs.map((n) =>
+    n.id === 'triples' && !isMaterialize
+      ? { ...n, label: 'triples', medallionLayer: 'bronze' as MedallionLayer }
+      : n
+  );
+
   const dagreGraph = new dagre.graphlib.Graph();
   dagreGraph.setDefaultEdgeLabel(() => ({}));
   dagreGraph.setGraph({ rankdir: 'LR', nodesep: 50, ranksep: 100, marginx: 20, marginy: 20 });
 
   // Add lineage nodes + source_systems_box to dagre for layout
-  nodeDefs.forEach((node) => {
+  effectiveNodeDefs.forEach((node) => {
     dagreGraph.setNode(node.id, { width: NODE_WIDTH, height: NODE_HEIGHT });
   });
   edgeDefs.forEach((edge) => {
@@ -373,7 +424,7 @@ function getLayoutedElements(
   let graphMinY = Infinity;
   let graphMaxY = -Infinity;
 
-  nodeDefs.forEach((nodeDef) => {
+  effectiveNodeDefs.forEach((nodeDef) => {
     const pos = dagreGraph.node(nodeDef.id);
     graphMinY = Math.min(graphMinY, pos.y - NODE_HEIGHT / 2);
     graphMaxY = Math.max(graphMaxY, pos.y + NODE_HEIGHT / 2);
@@ -415,23 +466,27 @@ function getLayoutedElements(
       };
     });
 
-  // FGAC wrapper band (behind bronze/silver/gold, with label above them)
-  const fgacMinX = Math.min(layerBounds.bronze.minX, layerBounds.silver.minX, layerBounds.gold.minX);
-  const fgacMaxX = Math.max(layerBounds.bronze.maxX, layerBounds.silver.maxX, layerBounds.gold.maxX);
-  const fgacLeft = fgacMinX - BAND_PADDING_X - FGAC_PAD;
-  const fgacTop = graphMinY - BAND_PADDING_Y - FGAC_LABEL_TOP - FGAC_PAD;
-  const fgacWidth = fgacMaxX - fgacMinX + (BAND_PADDING_X + FGAC_PAD) * 2;
-  const fgacHeight = graphMaxY - graphMinY + (BAND_PADDING_Y + FGAC_PAD) * 2 + FGAC_LABEL_TOP + FGAC_LABEL_BOTTOM;
+  // Outer wrapper band — spans bronze → gold in both scenarios.
+  // In Postgres mode, triples has been moved into bronze so sources is empty.
+  // In Materialize mode, sources stays separate (left of the wrapper).
+  const wrapperMinX = Math.min(layerBounds.bronze.minX, layerBounds.silver.minX, layerBounds.gold.minX);
+  const wrapperMaxX = Math.max(layerBounds.bronze.maxX, layerBounds.silver.maxX, layerBounds.gold.maxX);
+  const wrapperLeft = wrapperMinX - BAND_PADDING_X - FGAC_PAD;
+  // Materialize needs extra top room for the FGAC header rectangle; Postgres just needs padding
+  const wrapperLabelTop = isMaterialize ? FGAC_LABEL_TOP : FGAC_PAD;
+  const wrapperTop = graphMinY - BAND_PADDING_Y - wrapperLabelTop - FGAC_PAD;
+  const wrapperWidth = wrapperMaxX - wrapperMinX + (BAND_PADDING_X + FGAC_PAD) * 2;
+  const wrapperHeight = graphMaxY - graphMinY + (BAND_PADDING_Y + FGAC_PAD) * 2 + wrapperLabelTop + FGAC_LABEL_BOTTOM;
 
-  const fgacBandNode: Node = {
-    id: '__fgac__',
-    type: 'fgac_band',
-    position: { x: fgacLeft, y: fgacTop },
+  const outerBandNode: Node = {
+    id: isMaterialize ? '__fgac__' : '__source_wrapper__',
+    type: isMaterialize ? 'fgac_band' : 'source_wrapper_band',
+    position: { x: wrapperLeft, y: wrapperTop },
     style: {
-      width: fgacWidth,
-      height: fgacHeight,
-      background: 'rgba(124, 58, 237, 0.04)',
-      border: '1.5px solid rgba(124, 58, 237, 0.35)',
+      width: wrapperWidth,
+      height: wrapperHeight,
+      background: isMaterialize ? 'rgba(124, 58, 237, 0.04)' : 'rgba(30, 64, 175, 0.04)',
+      border: isMaterialize ? '1.5px solid rgba(124, 58, 237, 0.35)' : '1.5px solid rgba(30, 64, 175, 0.30)',
       borderRadius: '12px',
     },
     data: { label: '' },
@@ -442,9 +497,9 @@ function getLayoutedElements(
   };
 
   // Floating Agent + MCP nodes above the graph
-  const floatY = fgacTop - FLOAT_GAP - AGENT_H;
+  const floatY = wrapperTop - FLOAT_GAP - AGENT_H;
   const ssCenterX = (layerBounds.source_systems.minX + layerBounds.source_systems.maxX) / 2;
-  const fgacCenterX = fgacLeft + fgacWidth / 2;
+  const wrapperCenterX = wrapperLeft + wrapperWidth / 2;
 
   const agentNode: Node = {
     id: '__agent__',
@@ -461,7 +516,7 @@ function getLayoutedElements(
   const mcpNode: Node = {
     id: '__mcp__',
     type: 'mcp_node',
-    position: { x: fgacCenterX - MCP_W / 2, y: floatY },
+    position: { x: wrapperCenterX - MCP_W / 2, y: floatY },
     style: { width: MCP_W, height: MCP_H },
     data: { label: 'MCP Server' },
     zIndex: 2,
@@ -484,13 +539,14 @@ function getLayoutedElements(
   };
 
   // Lineage nodes
-  const nodes: Node[] = nodeDefs.map((nodeDef) => {
+  const nodes: Node[] = effectiveNodeDefs.map((nodeDef) => {
     const pos = dagreGraph.node(nodeDef.id);
     const isSelected = nodeDef.id === selectedNodeId;
     const isHighlighted = nodeDef.highlighted || false;
 
-    let style = getNodeStyle(nodeDef.type, isSelected);
-    if (isHighlighted && !isSelected) {
+    const effectiveType = !isMaterialize && nodeDef.type === 'mv' ? 'view' : nodeDef.type;
+    let style = getNodeStyle(effectiveType, isSelected);
+    if (isHighlighted && !isSelected && isMaterialize) {
       style = { ...style, border: '3px solid #059669', boxShadow: '0 0 10px rgba(16, 185, 129, 0.4)' };
     }
 
@@ -511,7 +567,8 @@ function getLayoutedElements(
     source: edgeDef.source,
     target: edgeDef.target,
     style: edgeStyle,
-    animated: true,
+    animated: isMaterialize,
+    markerStart: isMaterialize ? undefined : { type: MarkerType.ArrowClosed, color: '#94a3b8', orient: 'auto-start-reverse' },
     zIndex: 1,
   }));
 
@@ -523,7 +580,8 @@ function getLayoutedElements(
       target: 'triples',
       sourceHandle: 'right',
       style: edgeStyle,
-      animated: true,
+      animated: isMaterialize,
+      markerStart: isMaterialize ? undefined : { type: MarkerType.ArrowClosed, color: '#94a3b8', orient: 'auto-start-reverse' },
       zIndex: 1,
     },
     {
@@ -553,19 +611,23 @@ function getLayoutedElements(
       zIndex: 3,
     },
     {
-      id: 'e-mcp-fgac',
+      id: 'e-mcp-wrapper',
       source: '__mcp__',
-      target: '__fgac__',
+      target: isMaterialize ? '__fgac__' : '__source_wrapper__',
       sourceHandle: 'bottom',
       targetHandle: 'top',
-      style: { stroke: '#a855f7', strokeWidth: 1.5, strokeDasharray: '5,3' },
+      style: {
+        stroke: isMaterialize ? '#a855f7' : '#1e40af',
+        strokeWidth: 1.5,
+        strokeDasharray: '5,3',
+      },
       animated: false,
       zIndex: 3,
     },
   ];
 
   return {
-    nodes: [...bandNodes, fgacBandNode, agentNode, mcpNode, sourceSysNode, ...nodes],
+    nodes: [...bandNodes, outerBandNode, agentNode, mcpNode, sourceSysNode, ...nodes],
     edges: [...edges, ...overlayEdges],
   };
 }
@@ -573,12 +635,13 @@ function getLayoutedElements(
 interface LineageGraphProps {
   selectedNodeId?: string | null;
   onNodeClick?: (nodeId: string) => void;
+  scenario?: 'materialize' | 'postgres';
 }
 
-export function LineageGraph({ selectedNodeId, onNodeClick }: LineageGraphProps) {
+export function LineageGraph({ selectedNodeId, onNodeClick, scenario = 'materialize' }: LineageGraphProps) {
   const { nodes, edges } = useMemo(
-    () => getLayoutedElements(nodeDefinitions, edgeDefinitions, selectedNodeId),
-    [selectedNodeId]
+    () => getLayoutedElements(nodeDefinitions, edgeDefinitions, selectedNodeId, scenario),
+    [selectedNodeId, scenario]
   );
 
   const handleNodeClick: NodeMouseHandler = useCallback(

--- a/web/src/components/LineageGraph.tsx
+++ b/web/src/components/LineageGraph.tsx
@@ -78,7 +78,7 @@ const BandNode = ({ data }: { data: { layer: MedallionLayer } }) => {
     >
       <span
         style={{
-          fontSize: '10px',
+          fontSize: '12px',
           fontWeight: 700,
           letterSpacing: '0.1em',
           textTransform: 'uppercase',
@@ -99,24 +99,44 @@ const FgacBandNode = () => (
       width: '100%',
       height: '100%',
       display: 'flex',
-      alignItems: 'flex-start',
-      justifyContent: 'center',
-      paddingTop: '8px',
+      flexDirection: 'column',
+      justifyContent: 'space-between',
+      padding: '10px',
+      boxSizing: 'border-box',
       userSelect: 'none',
       pointerEvents: 'none',
     }}
   >
-    <span
+    {/* Header rectangle at top */}
+    <div
       style={{
-        fontSize: '10px',
-        fontWeight: 700,
-        letterSpacing: '0.06em',
-        color: '#7c3aed',
-        opacity: 0.85,
+        background: 'rgba(124, 58, 237, 0.12)',
+        border: '1px solid rgba(124, 58, 237, 0.45)',
+        borderRadius: '6px',
+        padding: '6px 14px',
+        textAlign: 'center',
+        flexShrink: 0,
       }}
     >
-      Fine-grained access control
-    </span>
+      <span style={{ fontSize: '13px', fontWeight: 700, color: '#7c3aed' }}>
+        Fine-grained access control
+      </span>
+    </div>
+    {/* Materialize branding at bottom */}
+    <div style={{ textAlign: 'center', paddingBottom: '2px' }}>
+      <span
+        style={{
+          fontSize: '13px',
+          fontWeight: 700,
+          color: '#7c3aed',
+          opacity: 0.5,
+          letterSpacing: '0.08em',
+          textTransform: 'uppercase',
+        }}
+      >
+        Materialize
+      </span>
+    </div>
     <Handle
       type="target"
       position={Position.Top}
@@ -146,7 +166,7 @@ const SourceSystemsNode = () => (
     <Handle type="target" position={Position.Top} id="top" style={{ opacity: 0 }} />
     <div
       style={{
-        fontSize: '10px',
+        fontSize: '12px',
         fontWeight: 700,
         color: '#374151',
         textAlign: 'center',
@@ -161,12 +181,12 @@ const SourceSystemsNode = () => (
       <div
         key={s}
         style={{
-          fontSize: '10px',
+          fontSize: '11px',
           color: '#475569',
           background: '#f1f5f9',
           border: '1px solid #e2e8f0',
           borderRadius: '4px',
-          padding: '2px 6px',
+          padding: '3px 6px',
           textAlign: 'center',
         }}
       >
@@ -196,8 +216,8 @@ const AgentNode = () => (
       userSelect: 'none',
     }}
   >
-    <span style={{ fontSize: '20px', lineHeight: 1 }}>🤖</span>
-    <span style={{ fontSize: '11px', fontWeight: 700, color: '#9a3412' }}>Agent</span>
+    <span style={{ fontSize: '22px', lineHeight: 1 }}>🤖</span>
+    <span style={{ fontSize: '13px', fontWeight: 700, color: '#9a3412' }}>Agent</span>
     <Handle type="source" position={Position.Right} id="right" style={{ opacity: 0 }} />
     <Handle type="source" position={Position.Bottom} id="bottom" style={{ opacity: 0 }} />
   </div>
@@ -222,8 +242,8 @@ const McpNode = () => (
       userSelect: 'none',
     }}
   >
-    <span style={{ fontSize: '16px', lineHeight: 1 }}>⚙️</span>
-    <span style={{ fontSize: '11px', fontWeight: 700, color: '#7e22ce' }}>MCP Server</span>
+    <span style={{ fontSize: '20px', lineHeight: 1 }}>⚙️</span>
+    <span style={{ fontSize: '13px', fontWeight: 700, color: '#7e22ce' }}>MCP Server</span>
     <Handle type="target" position={Position.Left} id="left" style={{ opacity: 0 }} />
     <Handle type="source" position={Position.Bottom} id="bottom" style={{ opacity: 0 }} />
   </div>
@@ -244,7 +264,7 @@ const getNodeStyle = (type: keyof typeof nodeColors, isSelected: boolean = false
   borderRadius: '8px',
   padding: '10px 16px',
   color: nodeColors[type].text,
-  fontSize: '12px',
+  fontSize: '13px',
   fontWeight: 500,
   minWidth: '120px',
   textAlign: 'center' as const,
@@ -303,20 +323,21 @@ const edgeDefinitions = [
 const edgeStyle = { stroke: '#94a3b8', strokeWidth: 2 };
 
 // Node dimensions for dagre layout
-const NODE_WIDTH = 150;
-const NODE_HEIGHT = 40;
-const BAND_PADDING_X = 18;
-const BAND_PADDING_Y = 28;
+const NODE_WIDTH = 168;
+const NODE_HEIGHT = 44;
+const BAND_PADDING_X = 20;
+const BAND_PADDING_Y = 32;
 // Source Systems box (taller to accommodate 4 items)
-const SS_W = 130;
-const SS_H = 118;
+const SS_W = 150;
+const SS_H = 136;
 // Floating nodes above the graph
-const AGENT_W = 88;
-const AGENT_H = 64;
-const MCP_W = 104;
-const MCP_H = 64;
-// FGAC wrapper extra space
-const FGAC_LABEL_TOP = 24;
+const AGENT_W = 100;
+const AGENT_H = 76;
+const MCP_W = 118;
+const MCP_H = 76;
+// FGAC wrapper extra space: top accommodates the header rectangle, bottom accommodates "Materialize"
+const FGAC_LABEL_TOP = 54;
+const FGAC_LABEL_BOTTOM = 32;
 const FGAC_PAD = 10;
 const FLOAT_GAP = 28;
 
@@ -400,7 +421,7 @@ function getLayoutedElements(
   const fgacLeft = fgacMinX - BAND_PADDING_X - FGAC_PAD;
   const fgacTop = graphMinY - BAND_PADDING_Y - FGAC_LABEL_TOP - FGAC_PAD;
   const fgacWidth = fgacMaxX - fgacMinX + (BAND_PADDING_X + FGAC_PAD) * 2;
-  const fgacHeight = graphMaxY - graphMinY + (BAND_PADDING_Y + FGAC_PAD) * 2 + FGAC_LABEL_TOP;
+  const fgacHeight = graphMaxY - graphMinY + (BAND_PADDING_Y + FGAC_PAD) * 2 + FGAC_LABEL_TOP + FGAC_LABEL_BOTTOM;
 
   const fgacBandNode: Node = {
     id: '__fgac__',
@@ -513,7 +534,7 @@ function getLayoutedElements(
       targetHandle: 'left',
       label: 'Observe',
       style: { stroke: '#6b7280', strokeWidth: 1.5 },
-      labelStyle: { fontSize: '10px', fill: '#6b7280', fontWeight: 600 },
+      labelStyle: { fontSize: '12px', fill: '#6b7280', fontWeight: 600 },
       labelBgStyle: { fill: '#f9fafb', fillOpacity: 0.85 },
       animated: false,
       zIndex: 3,
@@ -526,7 +547,7 @@ function getLayoutedElements(
       targetHandle: 'top',
       label: 'Act',
       style: { stroke: '#6b7280', strokeWidth: 1.5 },
-      labelStyle: { fontSize: '10px', fill: '#6b7280', fontWeight: 600 },
+      labelStyle: { fontSize: '12px', fill: '#6b7280', fontWeight: 600 },
       labelBgStyle: { fill: '#f9fafb', fillOpacity: 0.85 },
       animated: false,
       zIndex: 3,
@@ -573,7 +594,7 @@ export function LineageGraph({ selectedNodeId, onNodeClick }: LineageGraphProps)
   return (
     <div className="w-full">
       {/* Graph */}
-      <div className="h-[420px] w-full border border-gray-200 rounded-lg bg-gray-50">
+      <div className="h-[480px] w-full border border-gray-200 rounded-lg bg-gray-50">
         <ReactFlow
           nodes={nodes}
           edges={edges}

--- a/web/src/components/LineageGraph.tsx
+++ b/web/src/components/LineageGraph.tsx
@@ -506,7 +506,7 @@ function getLayoutedElements(
 
   const dagreGraph = new dagre.graphlib.Graph();
   dagreGraph.setDefaultEdgeLabel(() => ({}));
-  dagreGraph.setGraph({ rankdir: 'LR', nodesep: 50, ranksep: 100, marginx: 20, marginy: 20 });
+  dagreGraph.setGraph({ rankdir: 'LR', nodesep: 35, ranksep: 100, marginx: 20, marginy: 20 });
 
   // Add lineage nodes + source_systems_box to dagre for layout
   effectiveNodeDefs.forEach((node) => {
@@ -763,7 +763,7 @@ function getLayoutedElements(
       targetHandle: 'left',
       label: 'Observe',
       style: { stroke: '#6b7280', strokeWidth: 1.5 },
-      labelStyle: { fontSize: '12px', fill: '#6b7280', fontWeight: 600 },
+      labelStyle: { fontSize: '15px', fill: '#6b7280', fontWeight: 700 },
       labelBgStyle: { fill: '#f9fafb', fillOpacity: 0.85 },
       animated: true,
       zIndex: 3,
@@ -776,7 +776,7 @@ function getLayoutedElements(
       targetHandle: 'top',
       label: 'Act',
       style: { stroke: '#6b7280', strokeWidth: 1.5 },
-      labelStyle: { fontSize: '12px', fill: '#6b7280', fontWeight: 600 },
+      labelStyle: { fontSize: '15px', fill: '#6b7280', fontWeight: 700 },
       labelBgStyle: { fill: '#f9fafb', fillOpacity: 0.85 },
       animated: true,
       zIndex: 3,
@@ -828,14 +828,14 @@ export function LineageGraph({ selectedNodeId, onNodeClick, scenario = 'material
   return (
     <div className="w-full">
       {/* Graph */}
-      <div className="h-[480px] w-full border border-gray-200 rounded-lg bg-gray-50">
+      <div className="h-[720px] w-full border border-gray-200 rounded-lg bg-gray-50">
         <ReactFlow
           nodes={nodes}
           edges={edges}
           nodeTypes={nodeTypes}
           onNodeClick={handleNodeClick}
           fitView
-          fitViewOptions={{ padding: 0.15 }}
+          fitViewOptions={{ padding: 0.12 }}
           nodesDraggable={false}
           nodesConnectable={false}
           elementsSelectable={true}
@@ -876,14 +876,7 @@ export function LineageGraph({ selectedNodeId, onNodeClick, scenario = 'material
         )}
       </div>
 
-      {/* Description */}
-      <p className="mt-3 text-sm text-gray-500">
-        Three data products from the same <span className="font-medium text-blue-600">OLTP source</span>:{' '}
-        <span className="font-medium text-green-600">store_inventory_mv</span> (stock levels),{' '}
-        <span className="font-medium text-green-600">orders_with_lines_mv</span> (order details), and{' '}
-        <span className="font-medium text-green-600">dynamic_pricing_mv</span> (live pricing with 9 factors).
-        The agent observes via MCP and acts on source systems. Click any node to view its SQL.
-      </p>
+
     </div>
   );
 }

--- a/web/src/components/LineageGraph.tsx
+++ b/web/src/components/LineageGraph.tsx
@@ -13,7 +13,7 @@ import {
 import dagre from 'dagre';
 import '@xyflow/react/dist/style.css';
 
-type MedallionLayer = 'source_systems' | 'sources' | 'bronze' | 'silver' | 'gold';
+type MedallionLayer = 'source_systems' | 'sources' | 'bronze' | 'silver' | 'gold' | 'biz_logic';
 
 // Node type colors (object type)
 const nodeColors = {
@@ -61,10 +61,16 @@ const medallionColors: Record<MedallionLayer, {
     labelColor: '#854d0e',
     legendLabel: 'Gold',
   },
+  biz_logic: {
+    bg: 'rgba(99, 102, 241, 0.05)',
+    border: 'rgba(99, 102, 241, 0.28)',
+    labelColor: '#4338ca',
+    legendLabel: 'Business Logic',
+  },
 };
 
 // Swim-lane label band
-const BandNode = ({ data }: { data: { layer: MedallionLayer } }) => {
+const BandNode = ({ data }: { data: { layer: MedallionLayer; overrideLabel?: string } }) => {
   const colors = medallionColors[data.layer];
   return (
     <div
@@ -88,7 +94,7 @@ const BandNode = ({ data }: { data: { layer: MedallionLayer } }) => {
           opacity: 0.75,
         }}
       >
-        {colors.legendLabel}
+        {data.overrideLabel ?? colors.legendLabel}
       </span>
     </div>
   );
@@ -202,7 +208,7 @@ const OlapBandNode = () => (
   </div>
 );
 
-// Source wrapper band — Postgres scenario: covers Bronze + Silver + Gold
+// Source wrapper band — Postgres scenario: covers Bronze + Business Logic
 const SourceWrapperBandNode = () => (
   <div
     style={{
@@ -477,20 +483,18 @@ function getLayoutedElements(
     delivery_tasks_flat:'src_courier',
   };
 
-  // In Postgres mode: triples moves to Bronze; src_* nodes hidden.
-  // In Materialize/Batch: triples hidden; src_* nodes shown; edges remapped.
-  const effectiveNodeDefs = nodeDefs
-    .filter((n) => {
-      if (n.id === 'triples') return true; // always keep; visibility handled below
-      if (['src_customers', 'src_operations', 'src_courier'].includes(n.id)) return !isPostgres;
-      return true;
-    })
-    .map((n) => {
-      if (n.id === 'triples' && isPostgres)
-        return { ...n, label: 'triples', medallionLayer: 'bronze' as MedallionLayer };
-      return n;
-    })
-    .filter((n) => !(n.id === 'triples' && !isPostgres));
+  // Postgres: triples stays in bronze ("Base Tables"), all other content nodes remapped to biz_logic.
+  // Materialize/Batch: hide triples, show src_* nodes with remapped edges.
+  const effectiveNodeDefs = isPostgres
+    ? nodeDefs
+        .filter((n) => !['src_customers', 'src_operations', 'src_courier'].includes(n.id))
+        .map((n) => {
+          if (n.id === 'triples') return { ...n, label: 'triples', medallionLayer: 'bronze' as MedallionLayer };
+          if (['bronze', 'silver', 'gold'].includes(n.medallionLayer))
+            return { ...n, medallionLayer: 'biz_logic' as MedallionLayer };
+          return n;
+        })
+    : nodeDefs.filter((n) => n.id !== 'triples');
 
   const effectiveEdgeDefs = isPostgres
     ? edgeDefs
@@ -542,6 +546,7 @@ function getLayoutedElements(
     bronze: { minX: Infinity, maxX: -Infinity },
     silver: { minX: Infinity, maxX: -Infinity },
     gold: { minX: Infinity, maxX: -Infinity },
+    biz_logic: { minX: Infinity, maxX: -Infinity },
   };
   let graphMinY = Infinity;
   let graphMaxY = -Infinity;
@@ -562,12 +567,16 @@ function getLayoutedElements(
   layerBounds.source_systems.minX = ssPos.x - SS_W / 2;
   layerBounds.source_systems.maxX = ssPos.x + SS_W / 2;
 
-  // Swim-lane band nodes for each layer
+  // Swim-lane band nodes for each layer.
+  // Postgres shows only bronze (as "Base Tables") + biz_logic (as "Business Logic").
+  // Materialize/Batch show bronze/silver/gold; biz_logic is postgres-only.
   const bandNodes: Node[] = (Object.keys(layerBounds) as MedallionLayer[])
     .filter((layer) => layerBounds[layer].minX !== Infinity)
+    .filter((layer) => isPostgres ? (layer === 'bronze' || layer === 'biz_logic') : layer !== 'biz_logic')
     .map((layer) => {
       const b = layerBounds[layer];
       const colors = medallionColors[layer];
+      const overrideLabel = isPostgres && layer === 'bronze' ? 'Base Tables' : undefined;
       return {
         id: `__band__${layer}`,
         type: 'band',
@@ -580,7 +589,7 @@ function getLayoutedElements(
           borderRadius: '10px',
           pointerEvents: 'none' as const,
         },
-        data: { label: '', layer },
+        data: { label: '', layer, overrideLabel },
         zIndex: -1,
         selectable: false,
         draggable: false,
@@ -588,11 +597,9 @@ function getLayoutedElements(
       };
     });
 
-  // Outer wrapper band — spans bronze → gold in both scenarios.
-  // In Postgres mode, triples has been moved into bronze so sources is empty.
-  // In Materialize mode, sources stays separate (left of the wrapper).
-  const wrapperMinX = Math.min(layerBounds.bronze.minX, layerBounds.silver.minX, layerBounds.gold.minX);
-  const wrapperMaxX = Math.max(layerBounds.bronze.maxX, layerBounds.silver.maxX, layerBounds.gold.maxX);
+  // Outer wrapper band — spans bronze → gold (+ biz_logic for postgres).
+  const wrapperMinX = Math.min(layerBounds.bronze.minX, layerBounds.silver.minX, layerBounds.gold.minX, layerBounds.biz_logic.minX);
+  const wrapperMaxX = Math.max(layerBounds.bronze.maxX, layerBounds.silver.maxX, layerBounds.gold.maxX, layerBounds.biz_logic.maxX);
   const wrapperLeft = wrapperMinX - BAND_PADDING_X - FGAC_PAD;
   // All scenarios have a header rectangle, so all need the same top clearance
   const wrapperLabelTop = FGAC_LABEL_TOP;
@@ -674,12 +681,10 @@ function getLayoutedElements(
     const isSelected = nodeDef.id === selectedNodeId;
     const isHighlighted = nodeDef.highlighted || false;
 
-    // Postgres: MVs → view color, triples → tables color; Materialize/Batch keep originals
-    const effectiveType = isPostgres && nodeDef.type === 'mv'
-      ? 'view'
-      : isPostgres && nodeDef.id === 'triples'
-        ? 'tables'
-        : nodeDef.type;
+    // Postgres: triples → tables color; Materialize/Batch keep originals
+    const effectiveType = isPostgres && nodeDef.id === 'triples'
+      ? 'tables'
+      : nodeDef.type;
     let style = getNodeStyle(effectiveType, isSelected);
     if (isHighlighted && !isSelected && !isPostgres) {
       style = { ...style, border: '3px solid #059669', boxShadow: '0 0 10px rgba(16, 185, 129, 0.4)' };
@@ -699,18 +704,20 @@ function getLayoutedElements(
   // Lineage edges
   const srcNodeIds = new Set(['triples', 'src_customers', 'src_operations', 'src_courier']);
   const edges: Edge[] = effectiveEdgeDefs.map((edgeDef, index) => {
-    // In batch mode, edges from source nodes point forward; all others point backward.
+    // Forward arrow: batch edges from source nodes, or postgres triples→biz_logic
     const batchForward = isBatch && srcNodeIds.has(edgeDef.source);
+    const postgresForward = isPostgres && edgeDef.source === 'triples';
+    const useForwardArrow = batchForward || postgresForward;
     return {
       id: `e-${edgeDef.source}-${edgeDef.target}-${index}`,
       source: edgeDef.source,
       target: edgeDef.target,
       style: edgeStyle,
       animated: isMaterialize,
-      markerStart: (!isMaterialize && !batchForward)
+      markerStart: (!isMaterialize && !useForwardArrow)
         ? { type: MarkerType.ArrowClosed, color: '#94a3b8', orient: 'auto-start-reverse' }
         : undefined,
-      markerEnd: batchForward
+      markerEnd: useForwardArrow
         ? { type: MarkerType.ArrowClosed, color: '#94a3b8' }
         : undefined,
       zIndex: 1,
@@ -758,7 +765,7 @@ function getLayoutedElements(
       style: { stroke: '#6b7280', strokeWidth: 1.5 },
       labelStyle: { fontSize: '12px', fill: '#6b7280', fontWeight: 600 },
       labelBgStyle: { fill: '#f9fafb', fillOpacity: 0.85 },
-      animated: false,
+      animated: true,
       zIndex: 3,
     },
     {
@@ -771,7 +778,7 @@ function getLayoutedElements(
       style: { stroke: '#6b7280', strokeWidth: 1.5 },
       labelStyle: { fontSize: '12px', fill: '#6b7280', fontWeight: 600 },
       labelBgStyle: { fill: '#f9fafb', fillOpacity: 0.85 },
-      animated: false,
+      animated: true,
       zIndex: 3,
     },
     {
@@ -785,7 +792,7 @@ function getLayoutedElements(
         strokeWidth: 1.5,
         strokeDasharray: '5,3',
       },
-      animated: false,
+      animated: true,
       zIndex: 3,
     },
   ];

--- a/web/src/components/LineageGraph.tsx
+++ b/web/src/components/LineageGraph.tsx
@@ -11,7 +11,7 @@ import {
 import dagre from 'dagre';
 import '@xyflow/react/dist/style.css';
 
-type MedallionLayer = 'bronze' | 'silver' | 'gold';
+type MedallionLayer = 'sources' | 'bronze' | 'silver' | 'gold';
 
 // Node type colors (object type)
 const nodeColors = {
@@ -29,6 +29,13 @@ const medallionColors: Record<MedallionLayer, {
   legendDot: string;
   legendLabel: string;
 }> = {
+  sources: {
+    bg: 'rgba(59, 130, 246, 0.07)',
+    border: 'rgba(59, 130, 246, 0.28)',
+    labelColor: '#1d4ed8',
+    legendDot: '#3b82f6',
+    legendLabel: 'Sources',
+  },
   bronze: {
     bg: 'rgba(180, 83, 9, 0.07)',
     border: 'rgba(180, 83, 9, 0.28)',
@@ -109,7 +116,7 @@ const nodeDefinitions: Array<{
   medallionLayer: MedallionLayer;
   highlighted?: boolean;
 }> = [
-  { id: 'triples', label: 'triples', type: 'source', medallionLayer: 'bronze' },
+  { id: 'triples', label: 'OLTP', type: 'source', medallionLayer: 'sources' },
   { id: 'customers_flat', label: 'customers_flat', type: 'view', medallionLayer: 'bronze' },
   { id: 'stores_flat', label: 'stores_flat', type: 'view', medallionLayer: 'bronze' },
   { id: 'products_flat', label: 'products_flat', type: 'view', medallionLayer: 'bronze' },
@@ -198,6 +205,7 @@ function getLayoutedElements(
 
   // Compute bounding boxes per medallion layer and overall graph
   const layerBounds: Record<MedallionLayer, { minX: number; maxX: number }> = {
+    sources: { minX: Infinity, maxX: -Infinity },
     bronze: { minX: Infinity, maxX: -Infinity },
     silver: { minX: Infinity, maxX: -Infinity },
     gold: { minX: Infinity, maxX: -Infinity },
@@ -363,7 +371,7 @@ export function LineageGraph({ selectedNodeId, onNodeClick }: LineageGraphProps)
 
       {/* Description */}
       <p className="mt-3 text-sm text-gray-500">
-        Three data products from the same <span className="font-medium text-blue-600">triples</span> source:{' '}
+        Three data products from the same <span className="font-medium text-blue-600">OLTP source</span>:{' '}
         <span className="font-medium text-green-600">store_inventory_mv</span> (stock levels),{' '}
         <span className="font-medium text-green-600">orders_with_lines_mv</span> (order details), and{' '}
         <span className="font-medium text-green-600">dynamic_pricing_mv</span> (live pricing with 9 factors).

--- a/web/src/components/LineageGraph.tsx
+++ b/web/src/components/LineageGraph.tsx
@@ -126,7 +126,7 @@ const FgacBandNode = () => (
         flexShrink: 0,
       }}
     >
-      <span style={{ fontSize: '13px', fontWeight: 700, color: '#7c3aed' }}>
+      <span style={{ fontSize: '20px', fontWeight: 700, color: '#7c3aed' }}>
         Incremental View Maintenance via Timely Dataflow
       </span>
     </div>
@@ -149,6 +149,12 @@ const FgacBandNode = () => (
       type="target"
       position={Position.Top}
       id="top"
+      style={{ pointerEvents: 'all', opacity: 0 }}
+    />
+    <Handle
+      type="source"
+      position={Position.Top}
+      id="top-out"
       style={{ pointerEvents: 'all', opacity: 0 }}
     />
   </div>
@@ -180,7 +186,7 @@ const OlapBandNode = () => (
         flexShrink: 0,
       }}
     >
-      <span style={{ fontSize: '13px', fontWeight: 700, color: '#92400e' }}>
+      <span style={{ fontSize: '20px', fontWeight: 700, color: '#92400e' }}>
         Scheduled Refresh
       </span>
     </div>
@@ -203,6 +209,12 @@ const OlapBandNode = () => (
       type="target"
       position={Position.Top}
       id="top"
+      style={{ pointerEvents: 'all', opacity: 0 }}
+    />
+    <Handle
+      type="source"
+      position={Position.Top}
+      id="top-out"
       style={{ pointerEvents: 'all', opacity: 0 }}
     />
   </div>
@@ -234,7 +246,7 @@ const SourceWrapperBandNode = () => (
         flexShrink: 0,
       }}
     >
-      <span style={{ fontSize: '13px', fontWeight: 700, color: '#1e40af' }}>
+      <span style={{ fontSize: '20px', fontWeight: 700, color: '#1e40af' }}>
         Reactive query processing
       </span>
     </div>
@@ -257,6 +269,12 @@ const SourceWrapperBandNode = () => (
       type="target"
       position={Position.Top}
       id="top"
+      style={{ pointerEvents: 'all', opacity: 0 }}
+    />
+    <Handle
+      type="source"
+      position={Position.Top}
+      id="top-out"
       style={{ pointerEvents: 'all', opacity: 0 }}
     />
   </div>
@@ -333,8 +351,9 @@ const AgentNode = () => (
     }}
   >
     <span style={{ fontSize: '22px', lineHeight: 1 }}>🤖</span>
-    <span style={{ fontSize: '13px', fontWeight: 700, color: '#9a3412' }}>Agent</span>
+    <span style={{ fontSize: '20px', fontWeight: 700, color: '#9a3412' }}>Agent</span>
     <Handle type="source" position={Position.Right} id="right" style={{ opacity: 0 }} />
+    <Handle type="target" position={Position.Right} id="right-in" style={{ opacity: 0 }} />
     <Handle type="source" position={Position.Bottom} id="bottom" style={{ opacity: 0 }} />
   </div>
 );
@@ -359,9 +378,11 @@ const McpNode = () => (
     }}
   >
     <span style={{ fontSize: '20px', lineHeight: 1 }}>⚙️</span>
-    <span style={{ fontSize: '13px', fontWeight: 700, color: '#7e22ce' }}>MCP Server</span>
+    <span style={{ fontSize: '20px', fontWeight: 700, color: '#7e22ce' }}>MCP Server</span>
     <Handle type="target" position={Position.Left} id="left" style={{ opacity: 0 }} />
+    <Handle type="source" position={Position.Left} id="left-out" style={{ opacity: 0 }} />
     <Handle type="source" position={Position.Bottom} id="bottom" style={{ opacity: 0 }} />
+    <Handle type="target" position={Position.Bottom} id="bottom-in" style={{ opacity: 0 }} />
   </div>
 );
 
@@ -452,10 +473,10 @@ const BAND_PADDING_Y = 32;
 const SS_W = 150;
 const SS_H = 170;
 // Floating nodes above the graph
-const AGENT_W = 100;
-const AGENT_H = 76;
-const MCP_W = 118;
-const MCP_H = 76;
+const AGENT_W = 130;
+const AGENT_H = 90;
+const MCP_W = 155;
+const MCP_H = 90;
 // FGAC wrapper extra space: top accommodates the header rectangle, bottom accommodates "Materialize"
 const FGAC_LABEL_TOP = 54;
 const FGAC_LABEL_BOTTOM = 32;
@@ -757,10 +778,10 @@ function getLayoutedElements(
     ] : []),
     {
       id: 'e-agent-mcp',
-      source: '__agent__',
-      target: '__mcp__',
-      sourceHandle: 'right',
-      targetHandle: 'left',
+      source: '__mcp__',
+      target: '__agent__',
+      sourceHandle: 'left-out',
+      targetHandle: 'right-in',
       label: 'Observe',
       style: { stroke: '#6b7280', strokeWidth: 1.5 },
       labelStyle: { fontSize: '15px', fill: '#6b7280', fontWeight: 700 },
@@ -783,10 +804,10 @@ function getLayoutedElements(
     },
     {
       id: 'e-mcp-wrapper',
-      source: '__mcp__',
-      target: isMaterialize ? '__fgac__' : isBatch ? '__olap__' : '__source_wrapper__',
-      sourceHandle: 'bottom',
-      targetHandle: 'top',
+      source: isMaterialize ? '__fgac__' : isBatch ? '__olap__' : '__source_wrapper__',
+      target: '__mcp__',
+      sourceHandle: 'top-out',
+      targetHandle: 'bottom-in',
       style: {
         stroke: isMaterialize ? '#a855f7' : isBatch ? '#d97706' : '#1e40af',
         strokeWidth: 1.5,

--- a/web/src/components/PropagationWidget.tsx
+++ b/web/src/components/PropagationWidget.tsx
@@ -486,7 +486,7 @@ export default function PropagationWidget() {
 
       {/* Expanded content */}
       {isExpanded && (
-        <div className="h-[calc(40vh-2.5rem)] overflow-y-auto">
+        <div className="h-[calc(40vh-2.5rem)] overflow-y-auto select-text">
           {sourceWrites.length === 0 && displayedTimestamps.length === 0 ? (
             <div className="flex items-center justify-center h-full text-gray-500 text-sm">
               No propagation events yet - make a change to see updates flow through

--- a/web/src/components/PropagationWidget.tsx
+++ b/web/src/components/PropagationWidget.tsx
@@ -531,9 +531,7 @@ export default function PropagationWidget() {
                     <span className="text-xs font-medium text-green-400 uppercase tracking-wide">
                       Index Propagation
                     </span>
-                    <span className="text-xs text-gray-500">
-                      ({totalIndexUpdates} update{totalIndexUpdates !== 1 ? 's' : ''})
-                    </span>
+
                     {propagationLimitHit && (
                       <span className="text-xs text-yellow-500" title="Showing max 100 events per poll - more events may exist">
                         (limit reached)

--- a/web/src/components/SearchIndexUpdates.tsx
+++ b/web/src/components/SearchIndexUpdates.tsx
@@ -1,0 +1,114 @@
+import { useState, useEffect, useMemo } from "react";
+import { searchApi } from "../api/client";
+import { usePropagation } from "../contexts/PropagationContext";
+
+const VIRTUAL_SIZE = 65536;
+
+function hashDocId(id: string): number {
+  let h = 0;
+  for (let i = 0; i < id.length; i++) {
+    h = Math.imul(31, h) + id.charCodeAt(i) >>> 0;
+  }
+  return h % VIRTUAL_SIZE;
+}
+
+const OP_COLORS: Record<string, string> = {
+  INSERT: '#10b981',
+  UPDATE: '#a855f7',
+  DELETE: '#ef4444',
+};
+
+interface SearchIndexUpdatesProps {
+  writeTrigger: { mzLowerBound: number; wallClock: number } | null;
+}
+
+export const SearchIndexUpdates = ({ writeTrigger }: SearchIndexUpdatesProps) => {
+  const [impact, setImpact] = useState<{ impacted: number; total: number; pct: number } | null>(null);
+  const [watchingImpact, setWatchingImpact] = useState(false);
+  const { events } = usePropagation();
+
+  const marks = useMemo(() => {
+    if (!writeTrigger) return null;
+    const relevant = events.filter((e) => e.timestamp >= writeTrigger.wallClock);
+    if (relevant.length === 0) return null;
+    const seen = new Map<string, string>();
+    for (const e of relevant) {
+      seen.set(e.doc_id, OP_COLORS[e.operation] ?? '#6b7280');
+    }
+    return Array.from(seen.entries()).map(([doc_id, color]) => ({
+      doc_id,
+      color,
+      pct: (hashDocId(doc_id) / VIRTUAL_SIZE) * 100,
+    }));
+  }, [events, writeTrigger]);
+
+  useEffect(() => {
+    if (!writeTrigger) return;
+    let cancelled = false;
+    const watch = async () => {
+      setWatchingImpact(true);
+      setImpact(null);
+      let lastImpacted = -1;
+      for (let i = 0; i < 8; i++) {
+        await new Promise(r => setTimeout(r, 1000));
+        if (cancelled) break;
+        try {
+          const res = await searchApi.indexImpact(writeTrigger.mzLowerBound);
+          const data = res.data;
+          if (data.impacted > 0 && data.impacted === lastImpacted) break;
+          lastImpacted = data.impacted;
+          setImpact(data);
+        } catch {
+          break;
+        }
+      }
+      if (!cancelled) setWatchingImpact(false);
+    };
+    watch();
+    return () => { cancelled = true; };
+  }, [writeTrigger]);
+
+  return (
+    <div className="bg-gray-50 rounded-lg p-4">
+      <div className="flex items-center gap-2 mb-3">
+        <span className="font-medium text-gray-900">Search Index Updates</span>
+      </div>
+      <div className="relative h-4 rounded overflow-hidden bg-gray-200">
+        {marks?.map(({ doc_id, color, pct }) => (
+          <div
+            key={doc_id}
+            className="absolute top-0 bottom-0"
+            style={{ left: `${pct}%`, width: '2px', backgroundColor: color }}
+            title={doc_id}
+          />
+        ))}
+      </div>
+      {(watchingImpact || impact) && (
+        <div className="mt-1 text-xs text-gray-500 flex items-center gap-2">
+          {watchingImpact && !impact && (
+            <span className="text-gray-400 animate-pulse">Watching pipeline…</span>
+          )}
+          {impact && (
+            <>
+              <span className="font-mono font-semibold text-purple-700">{impact.impacted}</span>
+              <span className="text-gray-400">/</span>
+              <span className="font-mono text-gray-600">{impact.total}</span>
+              <span>docs re-indexed</span>
+              <span className={`font-semibold ${impact.pct > 10 ? 'text-orange-600' : 'text-purple-600'}`}>
+                ({impact.pct}%)
+              </span>
+              {watchingImpact && <span className="text-gray-400 animate-pulse">…</span>}
+            </>
+          )}
+          <div className="ml-auto flex items-center gap-3 text-gray-400">
+            <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm" style={{ backgroundColor: OP_COLORS.INSERT }} />insert</span>
+            <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm" style={{ backgroundColor: OP_COLORS.UPDATE }} />update</span>
+            <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm" style={{ backgroundColor: OP_COLORS.DELETE }} />delete</span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SearchIndexUpdates;

--- a/web/src/components/VectorPipelineCard.test.tsx
+++ b/web/src/components/VectorPipelineCard.test.tsx
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { VectorPipelineCard } from './VectorPipelineCard'
+
+// Mock the API client
+vi.mock('../api/client', () => ({
+  searchApi: {
+    vectorSearchOrders: vi.fn(),
+  },
+}))
+
+import { searchApi } from '../api/client'
+
+const mockResponse = {
+  data: {
+    results: [
+      {
+        order_id: 'order:FM-1001',
+        score: 0.92,
+        embedding_text: 'Whole Milk (Dairy) | Bananas (Produce)',
+        embedded_at: '2024-01-15T14:30:00Z',
+        order_number: 'FM-1001',
+        order_status: 'OUT_FOR_DELIVERY',
+        customer_name: 'Alex Thompson',
+        store_name: 'FreshMart Brooklyn',
+        store_zone: 'Brooklyn',
+        order_total_amount: 45.99,
+        effective_updated_at: '2024-01-15T14:35:00Z',
+      },
+    ],
+    query: 'dairy',
+    total: 1,
+  },
+}
+
+const emptyResponse = {
+  data: {
+    results: [],
+    query: 'nothing',
+    total: 0,
+  },
+}
+
+describe('VectorPipelineCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('Initial Render', () => {
+    it('renders collapsed by default', () => {
+      render(<VectorPipelineCard />)
+      expect(screen.getByText('Vector Pipeline')).toBeInTheDocument()
+      expect(screen.queryByPlaceholderText(/search/i)).not.toBeInTheDocument()
+    })
+
+    it('expands when header clicked', async () => {
+      render(<VectorPipelineCard />)
+      const headerButton = screen.getByRole('button', { name: /Vector Pipeline/i })
+      fireEvent.click(headerButton)
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument()
+      })
+    })
+
+    it('shows architecture steps when expanded', async () => {
+      render(<VectorPipelineCard />)
+      fireEvent.click(screen.getByRole('button', { name: /Vector Pipeline/i }))
+
+      await waitFor(() => {
+        expect(screen.getByText('Embed query')).toBeInTheDocument()
+        expect(screen.getByText('knn_search')).toBeInTheDocument()
+        expect(screen.getByText('Hydrate')).toBeInTheDocument()
+        expect(screen.getByText(/Merge/i)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('Search Functionality', () => {
+    it('performs search on button click', async () => {
+      vi.mocked(searchApi.vectorSearchOrders).mockResolvedValue(mockResponse as never)
+
+      render(<VectorPipelineCard />)
+      fireEvent.click(screen.getByRole('button', { name: /Vector Pipeline/i }))
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument()
+      })
+
+      const input = screen.getByPlaceholderText(/search/i)
+      const searchButton = screen.getByRole('button', { name: /^Search$/i })
+
+      fireEvent.change(input, { target: { value: 'dairy products' } })
+      fireEvent.click(searchButton)
+
+      await waitFor(() => {
+        expect(searchApi.vectorSearchOrders).toHaveBeenCalledWith('dairy products', 3)
+      })
+    })
+
+    it('performs search on Enter key', async () => {
+      vi.mocked(searchApi.vectorSearchOrders).mockResolvedValue(mockResponse as never)
+
+      render(<VectorPipelineCard />)
+      fireEvent.click(screen.getByRole('button', { name: /Vector Pipeline/i }))
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument()
+      })
+
+      const input = screen.getByPlaceholderText(/search/i)
+      fireEvent.change(input, { target: { value: 'organic produce' } })
+      fireEvent.keyDown(input, { key: 'Enter' })
+
+      await waitFor(() => {
+        expect(searchApi.vectorSearchOrders).toHaveBeenCalledWith('organic produce', 3)
+      })
+    })
+
+    it('shows order card after search', async () => {
+      vi.mocked(searchApi.vectorSearchOrders).mockResolvedValue(mockResponse as never)
+
+      render(<VectorPipelineCard />)
+      fireEvent.click(screen.getByRole('button', { name: /Vector Pipeline/i }))
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument()
+      })
+
+      const input = screen.getByPlaceholderText(/search/i)
+      fireEvent.change(input, { target: { value: 'dairy' } })
+      fireEvent.keyDown(input, { key: 'Enter' })
+
+      await waitFor(() => {
+        expect(screen.getByText(/FM-1001/)).toBeInTheDocument()
+        expect(screen.getByText('Alex Thompson')).toBeInTheDocument()
+      })
+    })
+
+    it('shows similarity score', async () => {
+      vi.mocked(searchApi.vectorSearchOrders).mockResolvedValue(mockResponse as never)
+
+      render(<VectorPipelineCard />)
+      fireEvent.click(screen.getByRole('button', { name: /Vector Pipeline/i }))
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument()
+      })
+
+      const input = screen.getByPlaceholderText(/search/i)
+      fireEvent.change(input, { target: { value: 'dairy' } })
+      fireEvent.keyDown(input, { key: 'Enter' })
+
+      await waitFor(() => {
+        expect(screen.getByText(/92\.0%/)).toBeInTheDocument()
+      })
+    })
+
+    it('shows embedding text', async () => {
+      vi.mocked(searchApi.vectorSearchOrders).mockResolvedValue(mockResponse as never)
+
+      render(<VectorPipelineCard />)
+      fireEvent.click(screen.getByRole('button', { name: /Vector Pipeline/i }))
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument()
+      })
+
+      const input = screen.getByPlaceholderText(/search/i)
+      fireEvent.change(input, { target: { value: 'dairy' } })
+      fireEvent.keyDown(input, { key: 'Enter' })
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Whole Milk (Dairy) | Bananas (Produce)')
+        ).toBeInTheDocument()
+      })
+    })
+
+    it('shows loading state', async () => {
+      vi.mocked(searchApi.vectorSearchOrders).mockImplementation(
+        () => new Promise((resolve) => setTimeout(() => resolve(mockResponse as never), 100))
+      )
+
+      render(<VectorPipelineCard />)
+      fireEvent.click(screen.getByRole('button', { name: /Vector Pipeline/i }))
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument()
+      })
+
+      const input = screen.getByPlaceholderText(/search/i)
+      fireEvent.change(input, { target: { value: 'dairy' } })
+      fireEvent.keyDown(input, { key: 'Enter' })
+
+      expect(screen.getByText(/Searching\.\.\./i)).toBeInTheDocument()
+
+      await waitFor(() => {
+        expect(screen.queryByText(/Searching\.\.\./i)).not.toBeInTheDocument()
+      })
+    })
+
+    it('shows error on failure', async () => {
+      vi.mocked(searchApi.vectorSearchOrders).mockRejectedValue(new Error('Network error'))
+
+      render(<VectorPipelineCard />)
+      fireEvent.click(screen.getByRole('button', { name: /Vector Pipeline/i }))
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument()
+      })
+
+      const input = screen.getByPlaceholderText(/search/i)
+      fireEvent.change(input, { target: { value: 'dairy' } })
+      fireEvent.keyDown(input, { key: 'Enter' })
+
+      await waitFor(() => {
+        expect(screen.getByText(/unavailable|error|failed/i)).toBeInTheDocument()
+      })
+    })
+
+    it('handles empty results gracefully', async () => {
+      vi.mocked(searchApi.vectorSearchOrders).mockResolvedValue(emptyResponse as never)
+
+      render(<VectorPipelineCard />)
+      fireEvent.click(screen.getByRole('button', { name: /Vector Pipeline/i }))
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument()
+      })
+
+      const input = screen.getByPlaceholderText(/search/i)
+      fireEvent.change(input, { target: { value: 'nothing' } })
+      fireEvent.keyDown(input, { key: 'Enter' })
+
+      await waitFor(() => {
+        expect(screen.getByText(/no results/i)).toBeInTheDocument()
+      })
+    })
+  })
+})

--- a/web/src/components/VectorPipelineCard.test.tsx
+++ b/web/src/components/VectorPipelineCard.test.tsx
@@ -94,7 +94,7 @@ describe('VectorPipelineCard', () => {
       fireEvent.click(searchButton)
 
       await waitFor(() => {
-        expect(searchApi.vectorSearchOrders).toHaveBeenCalledWith('dairy products', 3)
+        expect(searchApi.vectorSearchOrders).toHaveBeenCalledWith('dairy products', 5, expect.any(Object))
       })
     })
 
@@ -113,7 +113,7 @@ describe('VectorPipelineCard', () => {
       fireEvent.keyDown(input, { key: 'Enter' })
 
       await waitFor(() => {
-        expect(searchApi.vectorSearchOrders).toHaveBeenCalledWith('organic produce', 3)
+        expect(searchApi.vectorSearchOrders).toHaveBeenCalledWith('organic produce', 5, expect.any(Object))
       })
     })
 

--- a/web/src/components/VectorPipelineCard.tsx
+++ b/web/src/components/VectorPipelineCard.tsx
@@ -26,7 +26,7 @@ function downsample(vector: number[], bands: number): number[] {
   });
 }
 
-const EmbeddingStrip = ({ vector }: { vector: number[] }) => {
+const EmbeddingStrip = ({ vector, flashing }: { vector: number[]; flashing?: boolean }) => {
   if (!vector || vector.length < BANDS) {
     return <span className="text-xs text-gray-400 italic">—</span>;
   }
@@ -35,19 +35,23 @@ const EmbeddingStrip = ({ vector }: { vector: number[] }) => {
   const max = Math.max(...samples);
   const range = max - min || 1;
   return (
-    <div className="flex gap-px items-center" title={`384-dim embedding (${BANDS} bands shown)`}>
-      {samples.map((v, i) => {
-        const t = (v - min) / range; // 0 = min, 1 = max
-        // hue: 240 (indigo/low) → 0 (red/high), lightness 70 → 30
-        const hue = Math.round(240 - t * 240);
-        const lightness = Math.round(70 - t * 40);
-        return (
-          <div
-            key={i}
-            style={{ width: 3, height: 14, backgroundColor: `hsl(${hue}, 65%, ${lightness}%)` }}
-          />
-        );
-      })}
+    <div
+      className={`w-full rounded overflow-hidden transition-all duration-300 ${flashing ? "ring-2 ring-yellow-400 shadow-[0_0_12px_3px_rgba(250,204,21,0.5)]" : ""}`}
+      title={`384-dim embedding (${BANDS} bands shown)`}
+    >
+      <div className="flex w-full">
+        {samples.map((v, i) => {
+          const t = (v - min) / range;
+          const hue = Math.round(240 - t * 240);
+          const lightness = Math.round(70 - t * 40);
+          return (
+            <div
+              key={i}
+              style={{ flex: 1, height: 22, backgroundColor: `hsl(${hue}, 65%, ${lightness}%)` }}
+            />
+          );
+        })}
+      </div>
     </div>
   );
 };
@@ -109,10 +113,12 @@ export const VectorPipelineCard = () => {
   const [topResult, setTopResult]       = useState<VectorSearchResult | null>(null);
   const [hasSearched, setHasSearched]   = useState(false);
   // Per-line-item flash: set of line_ids (or indices) that changed on last refresh
-  const [flashedRows, setFlashedRows]   = useState<Set<number>>(new Set());
-  const [lastRefresh, setLastRefresh]   = useState<Date | null>(null);
-  const prevPricesRef = useRef<Record<number, number>>({});
-  const refreshTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [flashedRows, setFlashedRows]       = useState<Set<number>>(new Set());
+  const [embeddingFlashed, setEmbeddingFlashed] = useState(false);
+  const [lastRefresh, setLastRefresh]       = useState<Date | null>(null);
+  const prevPricesRef    = useRef<Record<number, number>>({});
+  const prevEmbeddedAtRef = useRef<string | null | undefined>(undefined);
+  const refreshTimerRef  = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const applyResult = useCallback((result: VectorSearchResult | null) => {
     if (!result) { setTopResult(null); return; }
@@ -126,11 +132,20 @@ export const VectorPipelineCard = () => {
       prevPricesRef.current[idx] = curr;
     });
 
+    // Detect embedding change
+    const prevEmbeddedAt = prevEmbeddedAtRef.current;
+    const embeddingChanged = prevEmbeddedAt !== undefined && prevEmbeddedAt !== result.embedded_at;
+    prevEmbeddedAtRef.current = result.embedded_at;
+
     setTopResult(result);
     setLastRefresh(new Date());
     if (newFlashed.size > 0) {
       setFlashedRows(newFlashed);
       setTimeout(() => setFlashedRows(new Set()), 1200);
+    }
+    if (embeddingChanged) {
+      setEmbeddingFlashed(true);
+      setTimeout(() => setEmbeddingFlashed(false), 2000);
     }
   }, []);
 
@@ -231,41 +246,38 @@ export const VectorPipelineCard = () => {
           </div>
 
           {/* Two-column layout */}
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 lg:grid-cols-[280px_1fr] gap-4">
             {/* Left: How it works */}
             <div className="border rounded-lg overflow-hidden">
               <div className="bg-gray-50 px-4 py-2 border-b">
                 <span className="text-sm font-medium text-gray-700">How it works</span>
               </div>
-              <div className="p-4 space-y-4">
-                <ol className="space-y-2">
+              <div className="p-3">
+                <ol className="flex flex-col gap-0">
                   {STEPS.map((step, idx) => {
                     const c = STEP_COLORS[step.color];
                     const Icon = step.icon;
                     return (
-                      <li key={step.label}>
-                        <div className={`flex items-start gap-3 p-3 rounded-md border ${c.bg} ${c.border}`}>
-                          <div className={`flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center ${c.icon}`}>
-                            <Icon className="h-4 w-4" />
+                      <li key={step.label} className="flex flex-col">
+                        <div className={`flex items-center gap-2 px-2 py-1.5 rounded border ${c.bg} ${c.border}`}>
+                          <div className={`flex-shrink-0 w-6 h-6 rounded-full flex items-center justify-center ${c.icon}`}>
+                            <Icon className="h-3 w-3" />
                           </div>
-                          <div className="flex-1 min-w-0">
-                            <div className="flex items-center gap-2">
-                              <span className="text-xs font-mono text-gray-400">{idx + 1}.</span>
-                              <span className={`text-sm font-semibold ${c.text}`}>{step.label}</span>
-                            </div>
-                            <p className="text-xs text-gray-600 mt-1">{step.detail}</p>
+                          <div className="flex items-baseline gap-1.5 min-w-0">
+                            <span className="text-xs font-mono text-gray-400">{idx + 1}.</span>
+                            <span className={`text-xs font-semibold ${c.text}`}>{step.label}</span>
+                            <span className="text-xs text-gray-500 truncate">{step.detail}</span>
                           </div>
                         </div>
                         {idx < STEPS.length - 1 && (
-                          <div className="flex justify-center py-1">
-                            <ArrowRight className="h-4 w-4 text-gray-400 rotate-90" />
+                          <div className="flex justify-center py-0.5">
+                            <ArrowRight className="h-3 w-3 text-gray-300 rotate-90" />
                           </div>
                         )}
                       </li>
                     );
                   })}
                 </ol>
-                <WriteTripleForm />
               </div>
             </div>
 
@@ -336,12 +348,15 @@ export const VectorPipelineCard = () => {
                     {/* Order embedding — one per order, stable until line items change */}
                     <div className="pt-2 border-t border-gray-200">
                       <div className="flex items-center justify-between mb-1">
-                        <span className="text-xs text-gray-500">
-                          Order embedding <span className="text-gray-400">(384-dim · stable until products change)</span>
+                        <span className="text-xs text-gray-500 flex items-center gap-1.5">
+                          Order embedding <span className="text-gray-400">(384-dim)</span>
+                          {embeddingFlashed && (
+                            <span className="text-yellow-600 font-semibold animate-pulse">↻ re-embedded</span>
+                          )}
                         </span>
                         <span className="text-xs text-gray-400 font-mono">embedded {fmtTime(topResult.embedded_at)}</span>
                       </div>
-                      <EmbeddingStrip vector={topResult.embedding} />
+                      <EmbeddingStrip vector={topResult.embedding} flashing={embeddingFlashed} />
                       <code className="block mt-1.5 bg-gray-100 text-xs font-mono text-gray-700 px-2 py-1.5 rounded break-words leading-relaxed">
                         {topResult.embedding_text}
                       </code>
@@ -420,6 +435,11 @@ export const VectorPipelineCard = () => {
                 )}
               </div>
             </div>
+          </div>
+
+          {/* Write a Triple — full-width row */}
+          <div className="mt-4">
+            <WriteTripleForm />
           </div>
         </div>
       )}

--- a/web/src/components/VectorPipelineCard.tsx
+++ b/web/src/components/VectorPipelineCard.tsx
@@ -106,9 +106,10 @@ interface ResultCardProps {
   rank: number;
   flashedRows: Set<number>;
   embeddingFlashing: boolean;
+  onSelectSubject?: (id: string) => void;
 }
 
-const ResultCard = ({ result, rank: _rank, flashedRows, embeddingFlashing }: ResultCardProps) => (
+const ResultCard = ({ result, rank: _rank, flashedRows, embeddingFlashing, onSelectSubject }: ResultCardProps) => (
   <div className="space-y-1.5">
     {/* Header row */}
     <div className="flex items-center gap-2 flex-wrap">
@@ -122,6 +123,13 @@ const ResultCard = ({ result, rank: _rank, flashedRows, embeddingFlashing }: Res
         {[result.customer_name, result.store_name && `${result.store_name}${result.store_zone ? ` (${result.store_zone})` : ""}`]
           .filter(Boolean).join(" · ")}
       </span>
+      <button
+        onClick={() => onSelectSubject?.(result.order_id)}
+        className="font-mono text-xs text-gray-400 hover:text-purple-600 hover:bg-purple-50 px-1.5 py-0.5 rounded border border-transparent hover:border-purple-200 transition-colors whitespace-nowrap"
+        title="Fill into Write Triple subject"
+      >
+        {result.order_id}
+      </button>
       <span className="ml-auto text-xs text-purple-700 font-semibold whitespace-nowrap">
         {(result.score * 100).toFixed(1)}% match
       </span>
@@ -219,6 +227,7 @@ export const VectorPipelineCard = () => {
   const [flashedRowsByResult, setFlashedRowsByResult] = useState<Record<number, Set<number>>>({});
   const [flashedEmbeddings, setFlashedEmbeddings]     = useState<Set<number>>(new Set());
   const [lastRefresh, setLastRefresh]       = useState<Date | null>(null);
+  const [writeSubject, setWriteSubject]     = useState("");
 
   // Keyed by order_id so they survive result reordering
   const prevPricesRef     = useRef<Record<string, Record<number, number>>>({});
@@ -359,7 +368,7 @@ export const VectorPipelineCard = () => {
 
           {/* Write a Triple */}
           <div className="mb-4">
-            <WriteTripleForm />
+            <WriteTripleForm initialSubject={writeSubject} />
           </div>
 
           {/* Two-column layout */}
@@ -436,6 +445,7 @@ export const VectorPipelineCard = () => {
                           rank={idx + 1}
                           flashedRows={flashedRowsByResult[idx] ?? new Set()}
                           embeddingFlashing={flashedEmbeddings.has(idx)}
+                          onSelectSubject={setWriteSubject}
                         />
                       </div>
                     ))}

--- a/web/src/components/VectorPipelineCard.tsx
+++ b/web/src/components/VectorPipelineCard.tsx
@@ -7,7 +7,7 @@ import {
   Database,
   ArrowRight,
 } from "lucide-react";
-import { searchApi, VectorSearchResult } from "../api/client";
+import { searchApi, VectorSearchResult, VectorLineItem } from "../api/client";
 
 type StepColor = "purple" | "blue" | "green" | "orange";
 
@@ -333,16 +333,10 @@ export const VectorPipelineCard = () => {
                     <div className="flex items-center justify-between">
                       <div className="flex items-center gap-2">
                         <span className="text-base font-bold text-gray-900">
-                          {topResult.order_number
-                            ? `#${topResult.order_number}`
-                            : topResult.order_id}
+                          #{topResult.order_number ?? topResult.order_id}
                         </span>
                         {topResult.order_status && (
-                          <span
-                            className={`px-2 py-0.5 text-xs font-medium rounded border ${getStatusClasses(
-                              topResult.order_status
-                            )}`}
-                          >
+                          <span className={`px-2 py-0.5 text-xs font-medium rounded border ${getStatusClasses(topResult.order_status)}`}>
                             {topResult.order_status}
                           </span>
                         )}
@@ -352,44 +346,76 @@ export const VectorPipelineCard = () => {
                       </span>
                     </div>
 
-                    {/* Customer */}
-                    {topResult.customer_name && (
-                      <div className="text-sm">
-                        <span className="text-gray-500">Customer: </span>
-                        <span className="font-medium text-gray-900">
-                          {topResult.customer_name}
-                        </span>
+                    {/* Customer + store */}
+                    <div className="grid grid-cols-2 gap-x-4 text-sm">
+                      {topResult.customer_name && (
+                        <div>
+                          <span className="text-gray-500 text-xs block">Customer</span>
+                          <span className="font-medium text-gray-900">{topResult.customer_name}</span>
+                        </div>
+                      )}
+                      {topResult.store_name && (
+                        <div>
+                          <span className="text-gray-500 text-xs block">Store</span>
+                          <span className="font-medium text-gray-900">
+                            {topResult.store_name}
+                            {topResult.store_zone && <span className="ml-1 text-xs text-gray-400">({topResult.store_zone})</span>}
+                          </span>
+                        </div>
+                      )}
+                    </div>
+
+                    {/* Line items with live pricing */}
+                    {topResult.line_items && topResult.line_items.length > 0 && (
+                      <div className="pt-2 border-t border-gray-200">
+                        <div className="text-xs text-gray-500 mb-1.5 flex items-center justify-between">
+                          <span>Line items (live from Materialize)</span>
+                          {topResult.order_total_amount != null && (
+                            <span className="font-medium text-gray-700">
+                              Total: ${parseFloat(String(topResult.order_total_amount)).toFixed(2)}
+                            </span>
+                          )}
+                        </div>
+                        <div className="space-y-1">
+                          {topResult.line_items.slice(0, 5).map((item: VectorLineItem, i: number) => (
+                            <div key={i} className="flex items-center justify-between text-xs bg-gray-50 rounded px-2 py-1">
+                              <div className="flex items-center gap-1.5 min-w-0">
+                                {item.perishable_flag && (
+                                  <span className="text-orange-400 flex-shrink-0" title="Perishable">⚡</span>
+                                )}
+                                <span className="text-gray-800 truncate">{item.product_name}</span>
+                                {item.category && <span className="text-gray-400 flex-shrink-0">({item.category})</span>}
+                                {item.quantity != null && <span className="text-gray-500 flex-shrink-0">×{item.quantity}</span>}
+                              </div>
+                              <div className="flex items-center gap-2 flex-shrink-0 ml-2">
+                                {item.live_price != null && item.base_price != null && item.live_price !== item.base_price ? (
+                                  <>
+                                    <span className="line-through text-gray-400">${Number(item.base_price).toFixed(2)}</span>
+                                    <span className={`font-medium ${Number(item.live_price) > Number(item.base_price) ? "text-red-600" : "text-green-600"}`}>
+                                      ${Number(item.live_price).toFixed(2)}
+                                    </span>
+                                  </>
+                                ) : (
+                                  <span className="text-gray-700 font-medium">
+                                    ${Number(item.live_price ?? item.unit_price ?? 0).toFixed(2)}
+                                  </span>
+                                )}
+                              </div>
+                            </div>
+                          ))}
+                          {topResult.line_items.length > 5 && (
+                            <div className="text-xs text-gray-400 text-center pt-1">
+                              +{topResult.line_items.length - 5} more items
+                            </div>
+                          )}
+                        </div>
                       </div>
                     )}
 
-                    {/* Store + zone */}
-                    {(topResult.store_name || topResult.store_zone) && (
-                      <div className="text-sm">
-                        <span className="text-gray-500">Store: </span>
-                        <span className="font-medium text-gray-900">
-                          {topResult.store_name}
-                          {topResult.store_zone &&
-                            ` (${topResult.store_zone})`}
-                        </span>
-                      </div>
-                    )}
-
-                    {/* Total */}
-                    {typeof topResult.order_total_amount === "number" && (
-                      <div className="text-sm">
-                        <span className="text-gray-500">Total: </span>
-                        <span className="font-medium text-gray-900">
-                          ${topResult.order_total_amount.toFixed(2)}
-                        </span>
-                      </div>
-                    )}
-
-                    {/* Embedding text */}
+                    {/* Embedded text */}
                     <div className="pt-2 border-t border-gray-200">
-                      <div className="text-xs text-gray-500 mb-1">
-                        Embedded text
-                      </div>
-                      <code className="block bg-gray-100 text-xs font-mono text-gray-800 px-2 py-1.5 rounded break-words">
+                      <div className="text-xs text-gray-500 mb-1">Embedded text <span className="text-gray-400">(384-dim vector)</span></div>
+                      <code className="block bg-gray-100 text-xs font-mono text-gray-700 px-2 py-1.5 rounded break-words leading-relaxed">
                         {topResult.embedding_text}
                       </code>
                     </div>
@@ -397,9 +423,7 @@ export const VectorPipelineCard = () => {
                     {/* Hydrated label */}
                     <div className="flex items-center gap-2 pt-2 border-t border-gray-200">
                       <Database className="h-3.5 w-3.5 text-green-600" />
-                      <span className="text-xs font-medium text-green-700">
-                        Hydrated from Materialize
-                      </span>
+                      <span className="text-xs font-medium text-green-700">Hydrated from Materialize</span>
                       <span className="text-xs text-gray-500 ml-auto">
                         {formatTimeAgo(topResult.effective_updated_at)}
                       </span>

--- a/web/src/components/VectorPipelineCard.tsx
+++ b/web/src/components/VectorPipelineCard.tsx
@@ -7,6 +7,7 @@ import {
 } from "lucide-react";
 import { searchApi, VectorSearchResult, VectorLineItem } from "../api/client";
 import { WriteTripleForm } from "./WriteTripleForm";
+import { SearchIndexUpdates } from "./SearchIndexUpdates";
 
 // ── Embedding fingerprint ─────────────────────────────────────────────────────
 
@@ -105,7 +106,7 @@ const ResultCard = ({ result, rank: _rank, flashedRows, embeddingFlashing, onSel
       </span>
     </div>
     {result.embedding_text && (
-      <code className="block bg-gray-100 text-xs font-mono text-gray-600 px-2 py-1 rounded break-words leading-relaxed">
+      <code className={`block text-xs font-mono px-2 py-1 rounded break-words leading-relaxed transition-all duration-300 ${embeddingFlashing ? "bg-yellow-950 text-yellow-300 ring-2 ring-yellow-400 shadow-[0_0_10px_2px_rgba(250,204,21,0.4)]" : "bg-gray-100 text-gray-600"}`}>
         {result.embedding_text}
       </code>
     )}
@@ -186,6 +187,7 @@ export const VectorPipelineCard = () => {
   const [flashedEmbeddings, setFlashedEmbeddings]     = useState<Set<number>>(new Set());
   const [lastRefresh, setLastRefresh]       = useState<Date | null>(null);
   const [writeSubject, setWriteSubject]     = useState("");
+  const [writeTrigger, setWriteTrigger]     = useState<{ mzLowerBound: number; wallClock: number } | null>(null);
   const [filterZone, setFilterZone]         = useState("");
   const [filterStatus, setFilterStatus]     = useState("");
 
@@ -358,7 +360,13 @@ export const VectorPipelineCard = () => {
 
           {/* Write a Triple */}
           <div className="mb-4">
-            <WriteTripleForm initialSubject={writeSubject} />
+            <WriteTripleForm
+              initialSubject={writeSubject}
+              onWriteComplete={(mzLowerBound, wallClock) => setWriteTrigger({ mzLowerBound, wallClock })}
+            />
+          </div>
+          <div className="mb-4">
+            <SearchIndexUpdates writeTrigger={writeTrigger} />
           </div>
 
           {/* Live order results */}

--- a/web/src/components/VectorPipelineCard.tsx
+++ b/web/src/components/VectorPipelineCard.tsx
@@ -384,6 +384,7 @@ export const VectorPipelineCard = () => {
                                       <div className="font-medium text-gray-800 truncate">
                                         {item.perishable_flag && <span className="text-orange-400 mr-1" title="Perishable">⚡</span>}
                                         {item.product_name ?? "—"}
+                                        {item.product_id && <span className="ml-1 text-gray-400 font-normal">({item.product_id})</span>}
                                       </div>
                                       {item.line_id && (
                                         <div className="text-gray-400 font-mono truncate" style={{ fontSize: "9px" }}>{item.line_id}</div>

--- a/web/src/components/VectorPipelineCard.tsx
+++ b/web/src/components/VectorPipelineCard.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import {
   ChevronDown,
   ChevronRight,
@@ -6,74 +6,52 @@ import {
   Zap,
   Database,
   ArrowRight,
+  RefreshCw,
 } from "lucide-react";
 import { searchApi, VectorSearchResult, VectorLineItem } from "../api/client";
 
-type StepColor = "purple" | "blue" | "green" | "orange";
+// ── Embedding strip ──────────────────────────────────────────────────────────
+// Downsample a 384-dim vector to `bands` colour blocks and render them as an
+// inline strip.  Each block maps a normalised float value to an HSL shade so
+// the strip changes perceptibly when ANY product in the order changes.
 
-interface Step {
-  label: string;
-  detail: string;
-  icon: React.ComponentType<{ className?: string }>;
-  color: StepColor;
+const BANDS = 32;
+
+function downsample(vector: number[], bands: number): number[] {
+  const chunkSize = Math.floor(vector.length / bands);
+  return Array.from({ length: bands }, (_, i) => {
+    const slice = vector.slice(i * chunkSize, (i + 1) * chunkSize);
+    return slice.reduce((a, b) => a + b, 0) / slice.length;
+  });
 }
 
-const STEPS: Step[] = [
-  {
-    label: "Embed query",
-    detail: "BAAI/bge-small-en-v1.5 (384-dim)",
-    icon: Zap,
-    color: "purple",
-  },
-  {
-    label: "knn_search",
-    detail: "OpenSearch finds similar order IDs",
-    icon: Search,
-    color: "blue",
-  },
-  {
-    label: "Hydrate",
-    detail: "Materialize: live status, price, ETA",
-    icon: Database,
-    color: "green",
-  },
-  {
-    label: "Merge & return",
-    detail: "Enriched result to agent",
-    icon: ArrowRight,
-    color: "orange",
-  },
-];
-
-const STEP_COLOR_CLASSES: Record<
-  StepColor,
-  { bg: string; text: string; border: string; iconBg: string }
-> = {
-  purple: {
-    bg: "bg-purple-50",
-    text: "text-purple-700",
-    border: "border-purple-200",
-    iconBg: "bg-purple-100 text-purple-600",
-  },
-  blue: {
-    bg: "bg-blue-50",
-    text: "text-blue-700",
-    border: "border-blue-200",
-    iconBg: "bg-blue-100 text-blue-600",
-  },
-  green: {
-    bg: "bg-green-50",
-    text: "text-green-700",
-    border: "border-green-200",
-    iconBg: "bg-green-100 text-green-600",
-  },
-  orange: {
-    bg: "bg-orange-50",
-    text: "text-orange-700",
-    border: "border-orange-200",
-    iconBg: "bg-orange-100 text-orange-600",
-  },
+const EmbeddingStrip = ({ vector }: { vector: number[] }) => {
+  if (!vector || vector.length < BANDS) {
+    return <span className="text-xs text-gray-400 italic">—</span>;
+  }
+  const samples = downsample(vector, BANDS);
+  const min = Math.min(...samples);
+  const max = Math.max(...samples);
+  const range = max - min || 1;
+  return (
+    <div className="flex gap-px items-center" title={`384-dim embedding (${BANDS} bands shown)`}>
+      {samples.map((v, i) => {
+        const t = (v - min) / range; // 0 = min, 1 = max
+        // hue: 240 (indigo/low) → 0 (red/high), lightness 70 → 30
+        const hue = Math.round(240 - t * 240);
+        const lightness = Math.round(70 - t * 40);
+        return (
+          <div
+            key={i}
+            style={{ width: 3, height: 14, backgroundColor: `hsl(${hue}, 65%, ${lightness}%)` }}
+          />
+        );
+      })}
+    </div>
+  );
 };
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
 
 const STATUS_BADGE_CLASSES: Record<string, string> = {
   OUT_FOR_DELIVERY: "bg-blue-100 text-blue-800 border-blue-300",
@@ -82,100 +60,125 @@ const STATUS_BADGE_CLASSES: Record<string, string> = {
   DELIVERED: "bg-green-100 text-green-800 border-green-300",
 };
 
-const getStatusClasses = (status?: string): string => {
-  if (!status) return "bg-gray-100 text-gray-800 border-gray-300";
-  return (
-    STATUS_BADGE_CLASSES[status] || "bg-gray-100 text-gray-800 border-gray-300"
-  );
+const getStatusClasses = (status?: string) =>
+  STATUS_BADGE_CLASSES[status ?? ""] ?? "bg-gray-100 text-gray-800 border-gray-300";
+
+const fmtTime = (iso?: string | null): string => {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
 };
 
-const formatTimeAgo = (timestamp?: string): string => {
-  if (!timestamp) return "just now";
-  const then = new Date(timestamp).getTime();
-  if (Number.isNaN(then)) return "just now";
-  const diffSec = Math.max(0, Math.floor((Date.now() - then) / 1000));
-  if (diffSec < 2) return "just now";
-  if (diffSec < 60) return `${diffSec}s ago`;
-  const diffMin = Math.floor(diffSec / 60);
-  if (diffMin < 60) return `${diffMin}m ago`;
-  const diffHr = Math.floor(diffMin / 60);
-  if (diffHr < 24) return `${diffHr}h ago`;
-  return `${Math.floor(diffHr / 24)}d ago`;
+const fmtAgo = (iso?: string | null): string => {
+  if (!iso) return "just now";
+  const sec = Math.max(0, Math.floor((Date.now() - new Date(iso).getTime()) / 1000));
+  if (sec < 2) return "just now";
+  if (sec < 60) return `${sec}s ago`;
+  if (sec < 3600) return `${Math.floor(sec / 60)}m ago`;
+  return `${Math.floor(sec / 3600)}h ago`;
 };
+
+// ── Architecture steps ───────────────────────────────────────────────────────
+
+type StepColor = "purple" | "blue" | "green" | "orange";
+
+const STEPS = [
+  { label: "Embed query",    detail: "BAAI/bge-small-en-v1.5 (384-dim)",    color: "purple" as StepColor, icon: Zap },
+  { label: "knn_search",     detail: "OpenSearch returns top-N order IDs",   color: "blue"   as StepColor, icon: Search },
+  { label: "Hydrate",        detail: "Materialize: live status, price, ETA", color: "green"  as StepColor, icon: Database },
+  { label: "Merge & return", detail: "Enriched result to agent",             color: "orange" as StepColor, icon: ArrowRight },
+];
+
+const STEP_COLORS: Record<StepColor, { bg: string; text: string; border: string; icon: string }> = {
+  purple: { bg: "bg-purple-50", text: "text-purple-700", border: "border-purple-200", icon: "bg-purple-100 text-purple-600" },
+  blue:   { bg: "bg-blue-50",   text: "text-blue-700",   border: "border-blue-200",   icon: "bg-blue-100 text-blue-600" },
+  green:  { bg: "bg-green-50",  text: "text-green-700",  border: "border-green-200",  icon: "bg-green-100 text-green-600" },
+  orange: { bg: "bg-orange-50", text: "text-orange-700", border: "border-orange-200", icon: "bg-orange-100 text-orange-600" },
+};
+
+// ── Main component ────────────────────────────────────────────────────────────
 
 export const VectorPipelineCard = () => {
-  const [isExpanded, setIsExpanded] = useState(false);
-  const [searchQuery, setSearchQuery] = useState("");
+  const [isExpanded, setIsExpanded]     = useState(false);
+  const [searchQuery, setSearchQuery]   = useState("");
   const [submittedQuery, setSubmittedQuery] = useState("");
-  const [isSearching, setIsSearching] = useState(false);
-  const [searchError, setSearchError] = useState<string | null>(null);
-  const [topResult, setTopResult] = useState<VectorSearchResult | null>(null);
-  const [hasSearched, setHasSearched] = useState(false);
+  const [isSearching, setIsSearching]   = useState(false);
+  const [searchError, setSearchError]   = useState<string | null>(null);
+  const [topResult, setTopResult]       = useState<VectorSearchResult | null>(null);
+  const [hasSearched, setHasSearched]   = useState(false);
+  // Per-line-item flash: set of line_ids (or indices) that changed on last refresh
+  const [flashedRows, setFlashedRows]   = useState<Set<number>>(new Set());
+  const [lastRefresh, setLastRefresh]   = useState<Date | null>(null);
+  const prevPricesRef = useRef<Record<number, number>>({});
+  const refreshTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  const executeSearch = useCallback(async (query: string) => {
-    if (!query) {
-      setTopResult(null);
-      setSearchError(null);
-      setSubmittedQuery("");
-      setHasSearched(false);
-      return;
-    }
+  const applyResult = useCallback((result: VectorSearchResult | null) => {
+    if (!result) { setTopResult(null); return; }
 
-    setIsSearching(true);
-    setSearchError(null);
-    setSubmittedQuery(query);
-    setHasSearched(true);
+    // Detect which rows changed price since last refresh
+    const newFlashed = new Set<number>();
+    (result.line_items ?? []).forEach((item, idx) => {
+      const prev = prevPricesRef.current[idx];
+      const curr = item.live_price ?? item.unit_price ?? 0;
+      if (prev !== undefined && prev !== curr) newFlashed.add(idx);
+      prevPricesRef.current[idx] = curr;
+    });
 
-    try {
-      const response = await searchApi.vectorSearchOrders(query, 3);
-      const first = response.data.results[0] ?? null;
-      setTopResult(first);
-    } catch (error) {
-      console.error("Vector search failed:", error);
-      setSearchError(
-        "Vector search unavailable. Ensure OpenSearch and the embedding service are running."
-      );
-      setTopResult(null);
-    } finally {
-      setIsSearching(false);
+    setTopResult(result);
+    setLastRefresh(new Date());
+    if (newFlashed.size > 0) {
+      setFlashedRows(newFlashed);
+      setTimeout(() => setFlashedRows(new Set()), 1200);
     }
   }, []);
 
-  const performSearch = useCallback(async () => {
-    const query = searchQuery.trim();
-    await executeSearch(query);
-  }, [searchQuery, executeSearch]);
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter") {
-      performSearch();
+  const executeSearch = useCallback(async (query: string, silent = false) => {
+    if (!query) {
+      setTopResult(null); setSearchError(null); setSubmittedQuery(""); setHasSearched(false);
+      return;
     }
-  };
+    if (!silent) { setIsSearching(true); setSearchError(null); setSubmittedQuery(query); setHasSearched(true); }
+    try {
+      const response = await searchApi.vectorSearchOrders(query, 3);
+      applyResult(response.data.results[0] ?? null);
+    } catch (err) {
+      if (!silent) {
+        console.error("Vector search failed:", err);
+        setSearchError("Vector search unavailable. Ensure OpenSearch and the embedding service are running.");
+        setTopResult(null);
+      }
+    } finally {
+      if (!silent) setIsSearching(false);
+    }
+  }, [applyResult]);
 
-  const handleExampleClick = (query: string) => {
-    setSearchQuery(query);
-    executeSearch(query);
-  };
+  // Auto-refresh every 5s after a successful search
+  useEffect(() => {
+    if (refreshTimerRef.current) clearInterval(refreshTimerRef.current);
+    if (!submittedQuery) return;
+    refreshTimerRef.current = setInterval(() => {
+      executeSearch(submittedQuery, true);
+    }, 5000);
+    return () => { if (refreshTimerRef.current) clearInterval(refreshTimerRef.current); };
+  }, [submittedQuery, executeSearch]);
+
+  const performSearch = useCallback(() => executeSearch(searchQuery.trim()), [searchQuery, executeSearch]);
+  const handleKeyDown = (e: React.KeyboardEvent) => { if (e.key === "Enter") performSearch(); };
+  const handleExampleClick = (q: string) => { setSearchQuery(q); executeSearch(q); };
 
   return (
     <div className="bg-white rounded-lg shadow mb-6">
+      {/* Header */}
       <button
         onClick={() => setIsExpanded(!isExpanded)}
         className="w-full p-4 flex items-center justify-between hover:bg-gray-50 transition-colors"
       >
         <div className="flex items-center gap-2">
-          {isExpanded ? (
-            <ChevronDown className="h-5 w-5 text-gray-500" />
-          ) : (
-            <ChevronRight className="h-5 w-5 text-gray-500" />
-          )}
+          {isExpanded ? <ChevronDown className="h-5 w-5 text-gray-500" /> : <ChevronRight className="h-5 w-5 text-gray-500" />}
           <div className="text-left">
-            <h3 className="text-lg font-semibold text-gray-900">
-              Vector Pipeline
-            </h3>
-            <p className="text-xs text-gray-500">
-              Semantic search + live data hydration from Materialize
-            </p>
+            <h3 className="text-lg font-semibold text-gray-900">Vector Pipeline</h3>
+            <p className="text-xs text-gray-500">Semantic search + live data hydration from Materialize</p>
           </div>
         </div>
       </button>
@@ -184,28 +187,23 @@ export const VectorPipelineCard = () => {
         <div className="px-6 pb-6">
           <div className="mb-4 text-sm text-gray-600 leading-relaxed">
             <p>
-              The vector store finds <em>which</em> documents match the
-              question semantically. Materialize provides <em>live data</em>{" "}
-              for those documents&mdash;always fresh, never stale.
+              The vector store finds <em>which</em> documents match semantically.
+              Materialize provides <em>live data</em> for those documents — always fresh, never stale.
             </p>
           </div>
 
-          {/* Search input */}
+          {/* Search box */}
           <div className="border rounded-lg overflow-hidden mb-4">
-            <div className="bg-gray-50 px-4 py-2 border-b">
-              <div className="flex items-center gap-2">
-                <Search className="h-4 w-4 text-purple-500" />
-                <span className="text-sm font-medium text-gray-700">
-                  Ask a semantic question
-                </span>
-              </div>
+            <div className="bg-gray-50 px-4 py-2 border-b flex items-center gap-2">
+              <Search className="h-4 w-4 text-purple-500" />
+              <span className="text-sm font-medium text-gray-700">Ask a semantic question</span>
             </div>
             <div className="p-4 space-y-3">
               <div className="flex gap-2">
                 <input
                   type="text"
                   value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
+                  onChange={e => setSearchQuery(e.target.value)}
                   onKeyDown={handleKeyDown}
                   placeholder="Search by meaning (e.g., dairy products)..."
                   className="flex-1 px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
@@ -219,29 +217,14 @@ export const VectorPipelineCard = () => {
                   Search
                 </button>
               </div>
-
               <div className="text-xs text-gray-500">
                 Try:{" "}
-                <button
-                  onClick={() => handleExampleClick("organic produce")}
-                  className="text-purple-600 hover:underline"
-                >
-                  organic produce
-                </button>
-                ,{" "}
-                <button
-                  onClick={() => handleExampleClick("dairy products")}
-                  className="text-purple-600 hover:underline"
-                >
-                  dairy products
-                </button>
-                ,{" "}
-                <button
-                  onClick={() => handleExampleClick("perishable delivery")}
-                  className="text-purple-600 hover:underline"
-                >
-                  perishable delivery
-                </button>
+                {["organic produce", "dairy products", "perishable delivery"].map((q, i) => (
+                  <span key={q}>
+                    {i > 0 && ", "}
+                    <button onClick={() => handleExampleClick(q)} className="text-purple-600 hover:underline">{q}</button>
+                  </span>
+                ))}
               </div>
             </div>
           </div>
@@ -251,39 +234,25 @@ export const VectorPipelineCard = () => {
             {/* Left: How it works */}
             <div className="border rounded-lg overflow-hidden">
               <div className="bg-gray-50 px-4 py-2 border-b">
-                <span className="text-sm font-medium text-gray-700">
-                  How it works
-                </span>
+                <span className="text-sm font-medium text-gray-700">How it works</span>
               </div>
               <div className="p-4">
                 <ol className="space-y-2">
                   {STEPS.map((step, idx) => {
+                    const c = STEP_COLORS[step.color];
                     const Icon = step.icon;
-                    const colors = STEP_COLOR_CLASSES[step.color];
                     return (
                       <li key={step.label}>
-                        <div
-                          className={`flex items-start gap-3 p-3 rounded-md border ${colors.bg} ${colors.border}`}
-                        >
-                          <div
-                            className={`flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center ${colors.iconBg}`}
-                          >
+                        <div className={`flex items-start gap-3 p-3 rounded-md border ${c.bg} ${c.border}`}>
+                          <div className={`flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center ${c.icon}`}>
                             <Icon className="h-4 w-4" />
                           </div>
                           <div className="flex-1 min-w-0">
                             <div className="flex items-center gap-2">
-                              <span className="text-xs font-mono text-gray-400">
-                                {idx + 1}.
-                              </span>
-                              <span
-                                className={`text-sm font-semibold ${colors.text}`}
-                              >
-                                {step.label}
-                              </span>
+                              <span className="text-xs font-mono text-gray-400">{idx + 1}.</span>
+                              <span className={`text-sm font-semibold ${c.text}`}>{step.label}</span>
                             </div>
-                            <p className="text-xs text-gray-600 mt-1">
-                              {step.detail}
-                            </p>
+                            <p className="text-xs text-gray-600 mt-1">{step.detail}</p>
                           </div>
                         </div>
                         {idx < STEPS.length - 1 && (
@@ -301,36 +270,33 @@ export const VectorPipelineCard = () => {
             {/* Right: Live order result */}
             <div className="border rounded-lg overflow-hidden">
               <div className="bg-gray-50 px-4 py-2 border-b flex items-center justify-between">
-                <span className="text-sm font-medium text-gray-700">
-                  Live order result
-                </span>
-                {submittedQuery && !isSearching && !searchError && (
-                  <span className="text-xs text-gray-500 font-mono truncate max-w-[60%]">
-                    "{submittedQuery}"
-                  </span>
-                )}
+                <span className="text-sm font-medium text-gray-700">Live order result</span>
+                <div className="flex items-center gap-2">
+                  {lastRefresh && (
+                    <span className="text-xs text-gray-400 flex items-center gap-1">
+                      <RefreshCw className="h-3 w-3" />
+                      {fmtAgo(lastRefresh.toISOString())}
+                    </span>
+                  )}
+                  {submittedQuery && !isSearching && !searchError && (
+                    <span className="text-xs text-gray-500 font-mono truncate max-w-[120px]">"{submittedQuery}"</span>
+                  )}
+                </div>
               </div>
+
               <div className="p-4">
                 {isSearching ? (
-                  <div className="text-sm text-gray-500 py-8 text-center">
-                    Searching...
-                  </div>
+                  <div className="text-sm text-gray-500 py-8 text-center">Searching...</div>
                 ) : searchError ? (
-                  <div className="text-sm text-red-600 py-8 text-center">
-                    {searchError}
-                  </div>
+                  <div className="text-sm text-red-600 py-8 text-center">{searchError}</div>
                 ) : !hasSearched ? (
-                  <div className="text-sm text-gray-400 py-8 text-center italic">
-                    Enter a query to see a live result...
-                  </div>
+                  <div className="text-sm text-gray-400 py-8 text-center italic">Enter a query to see a live result...</div>
                 ) : !topResult ? (
-                  <div className="text-sm text-gray-500 py-8 text-center">
-                    No results found.
-                  </div>
+                  <div className="text-sm text-gray-500 py-8 text-center">No results found.</div>
                 ) : (
                   <div className="space-y-3">
                     {/* Order header */}
-                    <div className="flex items-center justify-between">
+                    <div className="flex items-center justify-between flex-wrap gap-2">
                       <div className="flex items-center gap-2">
                         <span className="text-base font-bold text-gray-900">
                           #{topResult.order_number ?? topResult.order_id}
@@ -350,13 +316,13 @@ export const VectorPipelineCard = () => {
                     <div className="grid grid-cols-2 gap-x-4 text-sm">
                       {topResult.customer_name && (
                         <div>
-                          <span className="text-gray-500 text-xs block">Customer</span>
+                          <span className="text-gray-400 text-xs block">Customer</span>
                           <span className="font-medium text-gray-900">{topResult.customer_name}</span>
                         </div>
                       )}
                       {topResult.store_name && (
                         <div>
-                          <span className="text-gray-500 text-xs block">Store</span>
+                          <span className="text-gray-400 text-xs block">Store</span>
                           <span className="font-medium text-gray-900">
                             {topResult.store_name}
                             {topResult.store_zone && <span className="ml-1 text-xs text-gray-400">({topResult.store_zone})</span>}
@@ -365,56 +331,74 @@ export const VectorPipelineCard = () => {
                       )}
                     </div>
 
-                    {/* Line items with live pricing */}
+                    {/* Line items table */}
                     {topResult.line_items && topResult.line_items.length > 0 && (
                       <div className="pt-2 border-t border-gray-200">
-                        <div className="text-xs text-gray-500 mb-1.5 flex items-center justify-between">
-                          <span>Line items (live from Materialize)</span>
+                        <div className="text-xs text-gray-500 mb-2 flex items-center justify-between">
+                          <span>Line items — live from Materialize</span>
                           {topResult.order_total_amount != null && (
                             <span className="font-medium text-gray-700">
                               Total: ${parseFloat(String(topResult.order_total_amount)).toFixed(2)}
                             </span>
                           )}
                         </div>
-                        <div className="space-y-1">
-                          {topResult.line_items.slice(0, 5).map((item: VectorLineItem, i: number) => (
-                            <div key={i} className="flex items-center justify-between text-xs bg-gray-50 rounded px-2 py-1">
-                              <div className="flex items-center gap-1.5 min-w-0">
-                                {item.perishable_flag && (
-                                  <span className="text-orange-400 flex-shrink-0" title="Perishable">⚡</span>
-                                )}
-                                <span className="text-gray-800 truncate">{item.product_name}</span>
-                                {item.category && <span className="text-gray-400 flex-shrink-0">({item.category})</span>}
-                                {item.quantity != null && <span className="text-gray-500 flex-shrink-0">×{item.quantity}</span>}
-                              </div>
-                              <div className="flex items-center gap-2 flex-shrink-0 ml-2">
-                                {item.live_price != null && item.base_price != null && item.live_price !== item.base_price ? (
-                                  <>
-                                    <span className="line-through text-gray-400">${Number(item.base_price).toFixed(2)}</span>
-                                    <span className={`font-medium ${Number(item.live_price) > Number(item.base_price) ? "text-red-600" : "text-green-600"}`}>
-                                      ${Number(item.live_price).toFixed(2)}
-                                    </span>
-                                  </>
-                                ) : (
-                                  <span className="text-gray-700 font-medium">
-                                    ${Number(item.live_price ?? item.unit_price ?? 0).toFixed(2)}
-                                  </span>
-                                )}
-                              </div>
-                            </div>
-                          ))}
-                          {topResult.line_items.length > 5 && (
-                            <div className="text-xs text-gray-400 text-center pt-1">
-                              +{topResult.line_items.length - 5} more items
-                            </div>
-                          )}
+                        <div className="overflow-x-auto">
+                          <table className="w-full text-xs border-collapse">
+                            <thead>
+                              <tr className="text-left text-gray-400 border-b border-gray-200">
+                                <th className="pb-1 pr-2 font-medium">Product</th>
+                                <th className="pb-1 pr-2 font-medium">Cat</th>
+                                <th className="pb-1 pr-2 font-medium text-right">Qty</th>
+                                <th className="pb-1 pr-2 font-medium text-right">Live $</th>
+                                <th className="pb-1 pr-2 font-medium">▓▒░ Embedding</th>
+                                <th className="pb-1 pr-2 font-medium whitespace-nowrap">Embedded at</th>
+                                <th className="pb-1 font-medium whitespace-nowrap">Row updated</th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {topResult.line_items.map((item: VectorLineItem, idx: number) => {
+                                const priceUp   = item.live_price != null && item.base_price != null && Number(item.live_price) > Number(item.base_price);
+                                const priceDown = item.live_price != null && item.base_price != null && Number(item.live_price) < Number(item.base_price);
+                                const isFlashed = flashedRows.has(idx);
+                                return (
+                                  <tr
+                                    key={idx}
+                                    className="border-b border-gray-100 last:border-0 transition-colors duration-300"
+                                    style={isFlashed ? { backgroundColor: "#fef9c3" } : undefined}
+                                  >
+                                    <td className="py-1 pr-2 font-medium text-gray-800 max-w-[90px] truncate">
+                                      {item.perishable_flag && <span className="text-orange-400 mr-1" title="Perishable">⚡</span>}
+                                      {item.product_name ?? "—"}
+                                    </td>
+                                    <td className="py-1 pr-2 text-gray-500 whitespace-nowrap">{item.category ?? "—"}</td>
+                                    <td className="py-1 pr-2 text-right text-gray-700">{item.quantity ?? "—"}</td>
+                                    <td className="py-1 pr-2 text-right font-medium whitespace-nowrap">
+                                      {item.base_price != null && item.live_price != null && Number(item.live_price) !== Number(item.base_price) && (
+                                        <span className="line-through text-gray-400 mr-1">${Number(item.base_price).toFixed(2)}</span>
+                                      )}
+                                      <span className={priceUp ? "text-red-600" : priceDown ? "text-green-600" : "text-gray-800"}>
+                                        ${Number(item.live_price ?? item.unit_price ?? 0).toFixed(2)}
+                                      </span>
+                                    </td>
+                                    <td className="py-1 pr-2">
+                                      <EmbeddingStrip vector={topResult.embedding} />
+                                    </td>
+                                    <td className="py-1 pr-2 text-gray-500 whitespace-nowrap font-mono">{fmtTime(topResult.embedded_at)}</td>
+                                    <td className="py-1 text-gray-500 whitespace-nowrap font-mono">{fmtTime(topResult.effective_updated_at)}</td>
+                                  </tr>
+                                );
+                              })}
+                            </tbody>
+                          </table>
                         </div>
                       </div>
                     )}
 
-                    {/* Embedded text */}
+                    {/* Embedding text */}
                     <div className="pt-2 border-t border-gray-200">
-                      <div className="text-xs text-gray-500 mb-1">Embedded text <span className="text-gray-400">(384-dim vector)</span></div>
+                      <div className="text-xs text-gray-500 mb-1">
+                        Embedded text <span className="text-gray-400">(384-dim vector)</span>
+                      </div>
                       <code className="block bg-gray-100 text-xs font-mono text-gray-700 px-2 py-1.5 rounded break-words leading-relaxed">
                         {topResult.embedding_text}
                       </code>
@@ -424,9 +408,7 @@ export const VectorPipelineCard = () => {
                     <div className="flex items-center gap-2 pt-2 border-t border-gray-200">
                       <Database className="h-3.5 w-3.5 text-green-600" />
                       <span className="text-xs font-medium text-green-700">Hydrated from Materialize</span>
-                      <span className="text-xs text-gray-500 ml-auto">
-                        {formatTimeAgo(topResult.effective_updated_at)}
-                      </span>
+                      <span className="text-xs text-gray-500 ml-auto">{fmtAgo(topResult.effective_updated_at)}</span>
                     </div>
                   </div>
                 )}

--- a/web/src/components/VectorPipelineCard.tsx
+++ b/web/src/components/VectorPipelineCard.tsx
@@ -12,9 +12,6 @@ import { searchApi, VectorSearchResult, VectorLineItem } from "../api/client";
 import { WriteTripleForm } from "./WriteTripleForm";
 
 // ── Embedding strip ──────────────────────────────────────────────────────────
-// Downsample a 384-dim vector to `bands` colour blocks and render them as an
-// inline strip.  Each block maps a normalised float value to an HSL shade so
-// the strip changes perceptibly when ANY product in the order changes.
 
 const BANDS = 32;
 
@@ -26,7 +23,7 @@ function downsample(vector: number[], bands: number): number[] {
   });
 }
 
-const EmbeddingStrip = ({ vector, flashing }: { vector: number[]; flashing?: boolean }) => {
+const EmbeddingStrip = ({ vector, flashing, height = 16 }: { vector: number[]; flashing?: boolean; height?: number }) => {
   if (!vector || vector.length < BANDS) {
     return <span className="text-xs text-gray-400 italic">—</span>;
   }
@@ -47,7 +44,7 @@ const EmbeddingStrip = ({ vector, flashing }: { vector: number[]; flashing?: boo
           return (
             <div
               key={i}
-              style={{ flex: 1, height: 22, backgroundColor: `hsl(${hue}, 65%, ${lightness}%)` }}
+              style={{ flex: 1, height, backgroundColor: `hsl(${hue}, 65%, ${lightness}%)` }}
             />
           );
         })}
@@ -102,72 +99,187 @@ const STEP_COLORS: Record<StepColor, { bg: string; text: string; border: string;
   orange: { bg: "bg-orange-50", text: "text-orange-700", border: "border-orange-200", icon: "bg-orange-100 text-orange-600" },
 };
 
+// ── Compact result card ───────────────────────────────────────────────────────
+
+interface ResultCardProps {
+  result: VectorSearchResult;
+  rank: number;
+  flashedRows: Set<number>;
+  embeddingFlashing: boolean;
+}
+
+const ResultCard = ({ result, rank, flashedRows, embeddingFlashing }: ResultCardProps) => (
+  <div className="space-y-1.5">
+    {/* Header row */}
+    <div className="flex items-center gap-2 flex-wrap">
+      <span className="flex-shrink-0 w-5 h-5 rounded-full bg-purple-100 text-purple-700 text-xs font-bold flex items-center justify-center">
+        {rank}
+      </span>
+      <span className="font-semibold text-gray-900 text-sm">#{result.order_number ?? result.order_id}</span>
+      {result.order_status && (
+        <span className={`px-1.5 py-0.5 text-xs font-medium rounded border ${getStatusClasses(result.order_status)}`}>
+          {result.order_status}
+        </span>
+      )}
+      <span className="text-xs text-gray-500 truncate">
+        {[result.customer_name, result.store_name && `${result.store_name}${result.store_zone ? ` (${result.store_zone})` : ""}`]
+          .filter(Boolean).join(" · ")}
+      </span>
+      <span className="ml-auto text-xs text-purple-700 font-semibold whitespace-nowrap">
+        {(result.score * 100).toFixed(1)}% match
+      </span>
+    </div>
+
+    {/* Embedding strip */}
+    <div className="flex items-center gap-2">
+      <div className="flex-1">
+        <EmbeddingStrip vector={result.embedding} flashing={embeddingFlashing} height={12} />
+      </div>
+      <span className="text-xs text-gray-400 font-mono whitespace-nowrap flex-shrink-0">
+        {embeddingFlashing
+          ? <span className="text-yellow-600 font-semibold animate-pulse">↻ re-embedded</span>
+          : `emb ${fmtTime(result.embedded_at)}`}
+      </span>
+    </div>
+
+    {/* Line items */}
+    {result.line_items && result.line_items.length > 0 && (
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse" style={{ fontSize: "11px" }}>
+          <thead>
+            <tr className="text-left text-gray-400 border-b border-gray-100">
+              <th className="pb-0.5 pr-2 font-medium">Product</th>
+              <th className="pb-0.5 pr-2 font-medium">Cat</th>
+              <th className="pb-0.5 pr-2 font-medium text-right">Qty</th>
+              <th className="pb-0.5 pr-2 font-medium text-right">Live $</th>
+              <th className="pb-0.5 font-medium whitespace-nowrap">Updated</th>
+            </tr>
+          </thead>
+          <tbody>
+            {result.line_items.map((item: VectorLineItem, idx: number) => {
+              const priceUp   = item.live_price != null && item.base_price != null && Number(item.live_price) > Number(item.base_price);
+              const priceDown = item.live_price != null && item.base_price != null && Number(item.live_price) < Number(item.base_price);
+              return (
+                <tr
+                  key={idx}
+                  className="border-b border-gray-100 last:border-0 transition-colors duration-300"
+                  style={flashedRows.has(idx) ? { backgroundColor: "#fef9c3" } : undefined}
+                >
+                  <td className="py-0.5 pr-2 max-w-[120px]">
+                    <div className="font-medium text-gray-800 truncate">
+                      {item.perishable_flag && <span className="text-orange-400 mr-0.5" title="Perishable">⚡</span>}
+                      {item.product_name ?? "—"}
+                      {item.product_id && <span className="ml-1 text-gray-400 font-normal">({item.product_id})</span>}
+                    </div>
+                    {item.line_id && (
+                      <div className="text-gray-400 font-mono truncate" style={{ fontSize: "9px" }}>{item.line_id}</div>
+                    )}
+                  </td>
+                  <td className="py-0.5 pr-2 text-gray-500 whitespace-nowrap">{item.category ?? "—"}</td>
+                  <td className="py-0.5 pr-2 text-right text-gray-700">{item.quantity ?? "—"}</td>
+                  <td className="py-0.5 pr-2 text-right font-medium whitespace-nowrap">
+                    {item.base_price != null && item.live_price != null && Number(item.live_price) !== Number(item.base_price) && (
+                      <span className="line-through text-gray-400 mr-1">${Number(item.base_price).toFixed(2)}</span>
+                    )}
+                    <span className={priceUp ? "text-red-600" : priceDown ? "text-green-600" : "text-gray-800"}>
+                      ${Number(item.live_price ?? item.unit_price ?? 0).toFixed(2)}
+                    </span>
+                  </td>
+                  <td className="py-0.5 text-gray-400 whitespace-nowrap font-mono">{fmtTime(result.effective_updated_at)}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    )}
+
+    {/* Footer */}
+    <div className="flex items-center gap-1.5">
+      <Database className="h-3 w-3 text-green-500" />
+      <span className="text-xs text-green-700">Hydrated</span>
+      {result.order_total_amount != null && (
+        <span className="text-xs text-gray-500">· Total: ${parseFloat(String(result.order_total_amount)).toFixed(2)}</span>
+      )}
+      <span className="text-xs text-gray-400 ml-auto">{fmtAgo(result.effective_updated_at)}</span>
+    </div>
+  </div>
+);
+
 // ── Main component ────────────────────────────────────────────────────────────
 
 export const VectorPipelineCard = () => {
-  const [isExpanded, setIsExpanded]     = useState(false);
-  const [searchQuery, setSearchQuery]   = useState("");
+  const [isExpanded, setIsExpanded]         = useState(false);
+  const [searchQuery, setSearchQuery]       = useState("");
   const [submittedQuery, setSubmittedQuery] = useState("");
-  const [isSearching, setIsSearching]   = useState(false);
-  const [searchError, setSearchError]   = useState<string | null>(null);
-  const [topResult, setTopResult]       = useState<VectorSearchResult | null>(null);
-  const [hasSearched, setHasSearched]   = useState(false);
-  // Per-line-item flash: set of line_ids (or indices) that changed on last refresh
-  const [flashedRows, setFlashedRows]       = useState<Set<number>>(new Set());
-  const [embeddingFlashed, setEmbeddingFlashed] = useState(false);
+  const [isSearching, setIsSearching]       = useState(false);
+  const [searchError, setSearchError]       = useState<string | null>(null);
+  const [results, setResults]               = useState<VectorSearchResult[]>([]);
+  const [hasSearched, setHasSearched]       = useState(false);
+  const [flashedRowsByResult, setFlashedRowsByResult] = useState<Record<number, Set<number>>>({});
+  const [flashedEmbeddings, setFlashedEmbeddings]     = useState<Set<number>>(new Set());
   const [lastRefresh, setLastRefresh]       = useState<Date | null>(null);
-  const prevPricesRef    = useRef<Record<number, number>>({});
-  const prevEmbeddedAtRef = useRef<string | null | undefined>(undefined);
-  const refreshTimerRef  = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  const applyResult = useCallback((result: VectorSearchResult | null) => {
-    if (!result) { setTopResult(null); return; }
+  // Keyed by order_id so they survive result reordering
+  const prevPricesRef     = useRef<Record<string, Record<number, number>>>({});
+  const prevEmbeddedAtRef = useRef<Record<string, string | null | undefined>>({});
+  const refreshTimerRef   = useRef<ReturnType<typeof setInterval> | null>(null);
 
-    // Detect which rows changed price since last refresh
-    const newFlashed = new Set<number>();
-    (result.line_items ?? []).forEach((item, idx) => {
-      const prev = prevPricesRef.current[idx];
-      const curr = item.live_price ?? item.unit_price ?? 0;
-      if (prev !== undefined && prev !== curr) newFlashed.add(idx);
-      prevPricesRef.current[idx] = curr;
+  const applyResults = useCallback((newResults: VectorSearchResult[]) => {
+    const newFlashedRows: Record<number, Set<number>> = {};
+    const newFlashedEmbeddings = new Set<number>();
+
+    newResults.forEach((result, resultIdx) => {
+      const id = result.order_id;
+      const prevPrices = prevPricesRef.current[id] ?? {};
+      const rowFlash = new Set<number>();
+
+      (result.line_items ?? []).forEach((item, lineIdx) => {
+        const prev = prevPrices[lineIdx];
+        const curr = item.live_price ?? item.unit_price ?? 0;
+        if (prev !== undefined && prev !== curr) rowFlash.add(lineIdx);
+        prevPrices[lineIdx] = curr;
+      });
+      prevPricesRef.current[id] = prevPrices;
+      if (rowFlash.size > 0) newFlashedRows[resultIdx] = rowFlash;
+
+      const prevEmb = prevEmbeddedAtRef.current[id];
+      if (prevEmb !== undefined && prevEmb !== result.embedded_at) newFlashedEmbeddings.add(resultIdx);
+      prevEmbeddedAtRef.current[id] = result.embedded_at;
     });
 
-    // Detect embedding change
-    const prevEmbeddedAt = prevEmbeddedAtRef.current;
-    const embeddingChanged = prevEmbeddedAt !== undefined && prevEmbeddedAt !== result.embedded_at;
-    prevEmbeddedAtRef.current = result.embedded_at;
-
-    setTopResult(result);
+    setResults(newResults);
     setLastRefresh(new Date());
-    if (newFlashed.size > 0) {
-      setFlashedRows(newFlashed);
-      setTimeout(() => setFlashedRows(new Set()), 1200);
+
+    if (Object.keys(newFlashedRows).length > 0) {
+      setFlashedRowsByResult(newFlashedRows);
+      setTimeout(() => setFlashedRowsByResult({}), 1200);
     }
-    if (embeddingChanged) {
-      setEmbeddingFlashed(true);
-      setTimeout(() => setEmbeddingFlashed(false), 2000);
+    if (newFlashedEmbeddings.size > 0) {
+      setFlashedEmbeddings(newFlashedEmbeddings);
+      setTimeout(() => setFlashedEmbeddings(new Set()), 2000);
     }
   }, []);
 
   const executeSearch = useCallback(async (query: string, silent = false) => {
     if (!query) {
-      setTopResult(null); setSearchError(null); setSubmittedQuery(""); setHasSearched(false);
+      setResults([]); setSearchError(null); setSubmittedQuery(""); setHasSearched(false);
       return;
     }
     if (!silent) { setIsSearching(true); setSearchError(null); setSubmittedQuery(query); setHasSearched(true); }
     try {
       const response = await searchApi.vectorSearchOrders(query, 3);
-      applyResult(response.data.results[0] ?? null);
+      applyResults(response.data.results ?? []);
     } catch (err) {
       if (!silent) {
         console.error("Vector search failed:", err);
         setSearchError("Vector search unavailable. Ensure OpenSearch and the embedding service are running.");
-        setTopResult(null);
+        setResults([]);
       }
     } finally {
       if (!silent) setIsSearching(false);
     }
-  }, [applyResult]);
+  }, [applyResults]);
 
   // Auto-refresh every 5s after a successful search
   useEffect(() => {
@@ -212,7 +324,7 @@ export const VectorPipelineCard = () => {
           <div className="border rounded-lg overflow-hidden mb-4">
             <div className="bg-gray-50 px-4 py-2 border-b flex items-center gap-2">
               <Search className="h-4 w-4 text-purple-500" />
-              <span className="text-sm font-medium text-gray-700">Ask a semantic question</span>
+              <span className="text-sm font-medium text-gray-700">Semantic Search</span>
             </div>
             <div className="p-4 space-y-3">
               <div className="flex gap-2">
@@ -281,10 +393,13 @@ export const VectorPipelineCard = () => {
               </div>
             </div>
 
-            {/* Right: Live order result */}
+            {/* Right: Live order results */}
             <div className="border rounded-lg overflow-hidden">
               <div className="bg-gray-50 px-4 py-2 border-b flex items-center justify-between">
-                <span className="text-sm font-medium text-gray-700">Live order result</span>
+                <span className="text-sm font-medium text-gray-700">
+                  Live order results
+                  {results.length > 0 && <span className="ml-1.5 text-xs text-gray-400 font-normal">top {results.length} by relevance</span>}
+                </span>
                 <div className="flex items-center gap-2">
                   {lastRefresh && (
                     <span className="text-xs text-gray-400 flex items-center gap-1">
@@ -304,133 +419,21 @@ export const VectorPipelineCard = () => {
                 ) : searchError ? (
                   <div className="text-sm text-red-600 py-8 text-center">{searchError}</div>
                 ) : !hasSearched ? (
-                  <div className="text-sm text-gray-400 py-8 text-center italic">Enter a query to see a live result...</div>
-                ) : !topResult ? (
+                  <div className="text-sm text-gray-400 py-8 text-center italic">Enter a query to see live results...</div>
+                ) : results.length === 0 ? (
                   <div className="text-sm text-gray-500 py-8 text-center">No results found.</div>
                 ) : (
-                  <div className="space-y-3">
-                    {/* Order header */}
-                    <div className="flex items-center justify-between flex-wrap gap-2">
-                      <div className="flex items-center gap-2">
-                        <span className="text-base font-bold text-gray-900">
-                          #{topResult.order_number ?? topResult.order_id}
-                        </span>
-                        {topResult.order_status && (
-                          <span className={`px-2 py-0.5 text-xs font-medium rounded border ${getStatusClasses(topResult.order_status)}`}>
-                            {topResult.order_status}
-                          </span>
-                        )}
+                  <div className="divide-y divide-gray-100">
+                    {results.map((result, idx) => (
+                      <div key={result.order_id} className={idx > 0 ? "pt-3 mt-3" : ""}>
+                        <ResultCard
+                          result={result}
+                          rank={idx + 1}
+                          flashedRows={flashedRowsByResult[idx] ?? new Set()}
+                          embeddingFlashing={flashedEmbeddings.has(idx)}
+                        />
                       </div>
-                      <span className="text-xs text-purple-700 font-semibold">
-                        {(topResult.score * 100).toFixed(1)}% match
-                      </span>
-                    </div>
-
-                    {/* Customer + store */}
-                    <div className="grid grid-cols-2 gap-x-4 text-sm">
-                      {topResult.customer_name && (
-                        <div>
-                          <span className="text-gray-400 text-xs block">Customer</span>
-                          <span className="font-medium text-gray-900">{topResult.customer_name}</span>
-                        </div>
-                      )}
-                      {topResult.store_name && (
-                        <div>
-                          <span className="text-gray-400 text-xs block">Store</span>
-                          <span className="font-medium text-gray-900">
-                            {topResult.store_name}
-                            {topResult.store_zone && <span className="ml-1 text-xs text-gray-400">({topResult.store_zone})</span>}
-                          </span>
-                        </div>
-                      )}
-                    </div>
-
-                    {/* Order embedding — one per order, stable until line items change */}
-                    <div className="pt-2 border-t border-gray-200">
-                      <div className="flex items-center justify-between mb-1">
-                        <span className="text-xs text-gray-500 flex items-center gap-1.5">
-                          Order embedding <span className="text-gray-400">(384-dim)</span>
-                          {embeddingFlashed && (
-                            <span className="text-yellow-600 font-semibold animate-pulse">↻ re-embedded</span>
-                          )}
-                        </span>
-                        <span className="text-xs text-gray-400 font-mono">embedded {fmtTime(topResult.embedded_at)}</span>
-                      </div>
-                      <EmbeddingStrip vector={topResult.embedding} flashing={embeddingFlashed} />
-                      <code className="block mt-1.5 bg-gray-100 text-xs font-mono text-gray-700 px-2 py-1.5 rounded break-words leading-relaxed">
-                        {topResult.embedding_text}
-                      </code>
-                    </div>
-
-                    {/* Line items table */}
-                    {topResult.line_items && topResult.line_items.length > 0 && (
-                      <div className="pt-2 border-t border-gray-200">
-                        <div className="text-xs text-gray-500 mb-2 flex items-center justify-between">
-                          <span>Line items — live from Materialize</span>
-                          {topResult.order_total_amount != null && (
-                            <span className="font-medium text-gray-700">
-                              Total: ${parseFloat(String(topResult.order_total_amount)).toFixed(2)}
-                            </span>
-                          )}
-                        </div>
-                        <div className="overflow-x-auto">
-                          <table className="w-full text-xs border-collapse">
-                            <thead>
-                              <tr className="text-left text-gray-400 border-b border-gray-200">
-                                <th className="pb-1 pr-2 font-medium">Product</th>
-                                <th className="pb-1 pr-2 font-medium">Cat</th>
-                                <th className="pb-1 pr-2 font-medium text-right">Qty</th>
-                                <th className="pb-1 pr-2 font-medium text-right">Live $</th>
-                                <th className="pb-1 font-medium whitespace-nowrap">Row updated</th>
-                              </tr>
-                            </thead>
-                            <tbody>
-                              {topResult.line_items.map((item: VectorLineItem, idx: number) => {
-                                const priceUp   = item.live_price != null && item.base_price != null && Number(item.live_price) > Number(item.base_price);
-                                const priceDown = item.live_price != null && item.base_price != null && Number(item.live_price) < Number(item.base_price);
-                                const isFlashed = flashedRows.has(idx);
-                                return (
-                                  <tr
-                                    key={idx}
-                                    className="border-b border-gray-100 last:border-0 transition-colors duration-300"
-                                    style={isFlashed ? { backgroundColor: "#fef9c3" } : undefined}
-                                  >
-                                    <td className="py-1 pr-2 max-w-[110px]">
-                                      <div className="font-medium text-gray-800 truncate">
-                                        {item.perishable_flag && <span className="text-orange-400 mr-1" title="Perishable">⚡</span>}
-                                        {item.product_name ?? "—"}
-                                        {item.product_id && <span className="ml-1 text-gray-400 font-normal">({item.product_id})</span>}
-                                      </div>
-                                      {item.line_id && (
-                                        <div className="text-gray-400 font-mono truncate" style={{ fontSize: "9px" }}>{item.line_id}</div>
-                                      )}
-                                    </td>
-                                    <td className="py-1 pr-2 text-gray-500 whitespace-nowrap">{item.category ?? "—"}</td>
-                                    <td className="py-1 pr-2 text-right text-gray-700">{item.quantity ?? "—"}</td>
-                                    <td className="py-1 pr-2 text-right font-medium whitespace-nowrap">
-                                      {item.base_price != null && item.live_price != null && Number(item.live_price) !== Number(item.base_price) && (
-                                        <span className="line-through text-gray-400 mr-1">${Number(item.base_price).toFixed(2)}</span>
-                                      )}
-                                      <span className={priceUp ? "text-red-600" : priceDown ? "text-green-600" : "text-gray-800"}>
-                                        ${Number(item.live_price ?? item.unit_price ?? 0).toFixed(2)}
-                                      </span>
-                                    </td>
-                                    <td className="py-1 text-gray-500 whitespace-nowrap font-mono">{fmtTime(topResult.effective_updated_at)}</td>
-                                  </tr>
-                                );
-                              })}
-                            </tbody>
-                          </table>
-                        </div>
-                      </div>
-                    )}
-
-                    {/* Hydrated label */}
-                    <div className="flex items-center gap-2 pt-2 border-t border-gray-200">
-                      <Database className="h-3.5 w-3.5 text-green-600" />
-                      <span className="text-xs font-medium text-green-700">Hydrated from Materialize</span>
-                      <span className="text-xs text-gray-500 ml-auto">{fmtAgo(topResult.effective_updated_at)}</span>
-                    </div>
+                    ))}
                   </div>
                 )}
               </div>

--- a/web/src/components/VectorPipelineCard.tsx
+++ b/web/src/components/VectorPipelineCard.tsx
@@ -186,6 +186,8 @@ export const VectorPipelineCard = () => {
   const [flashedEmbeddings, setFlashedEmbeddings]     = useState<Set<number>>(new Set());
   const [lastRefresh, setLastRefresh]       = useState<Date | null>(null);
   const [writeSubject, setWriteSubject]     = useState("");
+  const [filterZone, setFilterZone]         = useState("");
+  const [filterStatus, setFilterStatus]     = useState("");
 
   // Keyed by order_id so they survive result reordering
   const prevPricesRef     = useRef<Record<string, Record<number, number>>>({});
@@ -235,7 +237,11 @@ export const VectorPipelineCard = () => {
     }
     if (!silent) { setIsSearching(true); setSearchError(null); setSubmittedQuery(query); setHasSearched(true); }
     try {
-      const response = await searchApi.vectorSearchOrders(query, 3);
+      const filters = {
+        ...(filterZone ? { store_zone: filterZone } : {}),
+        ...(filterStatus ? { order_status: filterStatus } : {}),
+      };
+      const response = await searchApi.vectorSearchOrders(query, 5, filters);
       applyResults(response.data.results ?? []);
     } catch (err) {
       if (!silent) {
@@ -246,7 +252,7 @@ export const VectorPipelineCard = () => {
     } finally {
       if (!silent) setIsSearching(false);
     }
-  }, [applyResults]);
+  }, [applyResults, filterZone, filterStatus]);
 
   // Auto-refresh every 5s after a successful search
   useEffect(() => {
@@ -311,6 +317,32 @@ export const VectorPipelineCard = () => {
                   <Search className="h-4 w-4" />
                   Search
                 </button>
+              </div>
+              <div className="flex gap-2 items-center">
+                <span className="text-xs text-gray-500">Filters:</span>
+                <select
+                  value={filterZone}
+                  onChange={e => setFilterZone(e.target.value)}
+                  className="px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+                >
+                  <option value="">All zones</option>
+                  <option value="MAN">MAN</option>
+                  <option value="BK">BK</option>
+                  <option value="QNS">QNS</option>
+                  <option value="BX">BX</option>
+                  <option value="SI">SI</option>
+                </select>
+                <select
+                  value={filterStatus}
+                  onChange={e => setFilterStatus(e.target.value)}
+                  className="px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+                >
+                  <option value="">All statuses</option>
+                  <option value="CREATED">CREATED</option>
+                  <option value="PICKING">PICKING</option>
+                  <option value="OUT_FOR_DELIVERY">OUT_FOR_DELIVERY</option>
+                  <option value="DELIVERED">DELIVERED</option>
+                </select>
               </div>
               <div className="text-xs text-gray-500">
                 Try:{" "}

--- a/web/src/components/VectorPipelineCard.tsx
+++ b/web/src/components/VectorPipelineCard.tsx
@@ -8,45 +8,25 @@ import {
 import { searchApi, VectorSearchResult, VectorLineItem } from "../api/client";
 import { WriteTripleForm } from "./WriteTripleForm";
 
-// ── Embedding strip ──────────────────────────────────────────────────────────
+// ── Embedding fingerprint ─────────────────────────────────────────────────────
 
-const BANDS = 32;
-
-function downsample(vector: number[], bands: number): number[] {
-  const chunkSize = Math.floor(vector.length / bands);
-  return Array.from({ length: bands }, (_, i) => {
-    const slice = vector.slice(i * chunkSize, (i + 1) * chunkSize);
-    return slice.reduce((a, b) => a + b, 0) / slice.length;
-  });
+function embeddingFingerprint(vector: number[]): string {
+  if (!vector || vector.length < 8) return '—';
+  return vector.slice(0, 12)
+    .map(v => Math.round(((v + 1) / 2) * 255) & 0xff)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join(' ') + '…';
 }
 
-const EmbeddingStrip = ({ vector, flashing, height = 16 }: { vector: number[]; flashing?: boolean; height?: number }) => {
-  if (!vector || vector.length < BANDS) {
-    return <span className="text-xs text-gray-400 italic">—</span>;
-  }
-  const samples = downsample(vector, BANDS);
-  const min = Math.min(...samples);
-  const max = Math.max(...samples);
-  const range = max - min || 1;
+const EmbeddingStrip = ({ vector, flashing }: { vector: number[]; flashing?: boolean; height?: number }) => {
+  const fp = embeddingFingerprint(vector);
   return (
-    <div
-      className={`w-full rounded overflow-hidden transition-all duration-300 ${flashing ? "ring-2 ring-yellow-400 shadow-[0_0_12px_3px_rgba(250,204,21,0.5)]" : ""}`}
-      title={`384-dim embedding (${BANDS} bands shown)`}
+    <span
+      className={`font-mono text-xs flex-1 transition-all duration-300 ${flashing ? "text-yellow-400 font-semibold" : "text-gray-400"}`}
+      title="384-dim embedding vector (first 12 values as hex)"
     >
-      <div className="flex w-full">
-        {samples.map((v, i) => {
-          const t = (v - min) / range;
-          const hue = Math.round(240 - t * 240);
-          const lightness = Math.round(70 - t * 40);
-          return (
-            <div
-              key={i}
-              style={{ flex: 1, height, backgroundColor: `hsl(${hue}, 65%, ${lightness}%)` }}
-            />
-          );
-        })}
-      </div>
-    </div>
+      {fp}
+    </span>
   );
 };
 
@@ -114,15 +94,14 @@ const ResultCard = ({ result, rank: _rank, flashedRows, embeddingFlashing, onSel
       </span>
     </div>
 
-    {/* Embedding strip + text */}
-    <div className="flex items-center gap-2">
-      <div className="flex-1">
-        <EmbeddingStrip vector={result.embedding} flashing={embeddingFlashing} height={12} />
-      </div>
-      <span className="text-xs text-gray-400 font-mono whitespace-nowrap flex-shrink-0">
+    {/* Embedding fingerprint bar */}
+    <div className={`flex items-center gap-2 bg-gray-900 rounded px-2 py-1 transition-all duration-300 ${embeddingFlashing ? "ring-2 ring-yellow-400 shadow-[0_0_10px_2px_rgba(250,204,21,0.4)]" : ""}`}>
+      <span className="text-xs font-medium text-gray-500 whitespace-nowrap flex-shrink-0">emb</span>
+      <EmbeddingStrip vector={result.embedding} flashing={embeddingFlashing} />
+      <span className="text-xs text-gray-500 font-mono whitespace-nowrap flex-shrink-0">
         {embeddingFlashing
-          ? <span className="text-yellow-600 font-semibold animate-pulse">↻ re-embedded</span>
-          : `emb ${fmtTime(result.embedded_at)}`}
+          ? <span className="text-yellow-400 font-semibold animate-pulse">↻ re-embedded</span>
+          : fmtTime(result.embedded_at)}
       </span>
     </div>
     {result.embedding_text && (

--- a/web/src/components/VectorPipelineCard.tsx
+++ b/web/src/components/VectorPipelineCard.tsx
@@ -380,9 +380,14 @@ export const VectorPipelineCard = () => {
                                     className="border-b border-gray-100 last:border-0 transition-colors duration-300"
                                     style={isFlashed ? { backgroundColor: "#fef9c3" } : undefined}
                                   >
-                                    <td className="py-1 pr-2 font-medium text-gray-800 max-w-[90px] truncate">
-                                      {item.perishable_flag && <span className="text-orange-400 mr-1" title="Perishable">⚡</span>}
-                                      {item.product_name ?? "—"}
+                                    <td className="py-1 pr-2 max-w-[110px]">
+                                      <div className="font-medium text-gray-800 truncate">
+                                        {item.perishable_flag && <span className="text-orange-400 mr-1" title="Perishable">⚡</span>}
+                                        {item.product_name ?? "—"}
+                                      </div>
+                                      {item.line_id && (
+                                        <div className="text-gray-400 font-mono truncate" style={{ fontSize: "9px" }}>{item.line_id}</div>
+                                      )}
                                     </td>
                                     <td className="py-1 pr-2 text-gray-500 whitespace-nowrap">{item.category ?? "—"}</td>
                                     <td className="py-1 pr-2 text-right text-gray-700">{item.quantity ?? "—"}</td>

--- a/web/src/components/VectorPipelineCard.tsx
+++ b/web/src/components/VectorPipelineCard.tsx
@@ -331,6 +331,20 @@ export const VectorPipelineCard = () => {
                       )}
                     </div>
 
+                    {/* Order embedding — one per order, stable until line items change */}
+                    <div className="pt-2 border-t border-gray-200">
+                      <div className="flex items-center justify-between mb-1">
+                        <span className="text-xs text-gray-500">
+                          Order embedding <span className="text-gray-400">(384-dim · stable until products change)</span>
+                        </span>
+                        <span className="text-xs text-gray-400 font-mono">embedded {fmtTime(topResult.embedded_at)}</span>
+                      </div>
+                      <EmbeddingStrip vector={topResult.embedding} />
+                      <code className="block mt-1.5 bg-gray-100 text-xs font-mono text-gray-700 px-2 py-1.5 rounded break-words leading-relaxed">
+                        {topResult.embedding_text}
+                      </code>
+                    </div>
+
                     {/* Line items table */}
                     {topResult.line_items && topResult.line_items.length > 0 && (
                       <div className="pt-2 border-t border-gray-200">
@@ -350,8 +364,6 @@ export const VectorPipelineCard = () => {
                                 <th className="pb-1 pr-2 font-medium">Cat</th>
                                 <th className="pb-1 pr-2 font-medium text-right">Qty</th>
                                 <th className="pb-1 pr-2 font-medium text-right">Live $</th>
-                                <th className="pb-1 pr-2 font-medium">▓▒░ Embedding</th>
-                                <th className="pb-1 pr-2 font-medium whitespace-nowrap">Embedded at</th>
                                 <th className="pb-1 font-medium whitespace-nowrap">Row updated</th>
                               </tr>
                             </thead>
@@ -380,10 +392,6 @@ export const VectorPipelineCard = () => {
                                         ${Number(item.live_price ?? item.unit_price ?? 0).toFixed(2)}
                                       </span>
                                     </td>
-                                    <td className="py-1 pr-2">
-                                      <EmbeddingStrip vector={topResult.embedding} />
-                                    </td>
-                                    <td className="py-1 pr-2 text-gray-500 whitespace-nowrap font-mono">{fmtTime(topResult.embedded_at)}</td>
                                     <td className="py-1 text-gray-500 whitespace-nowrap font-mono">{fmtTime(topResult.effective_updated_at)}</td>
                                   </tr>
                                 );
@@ -393,16 +401,6 @@ export const VectorPipelineCard = () => {
                         </div>
                       </div>
                     )}
-
-                    {/* Embedding text */}
-                    <div className="pt-2 border-t border-gray-200">
-                      <div className="text-xs text-gray-500 mb-1">
-                        Embedded text <span className="text-gray-400">(384-dim vector)</span>
-                      </div>
-                      <code className="block bg-gray-100 text-xs font-mono text-gray-700 px-2 py-1.5 rounded break-words leading-relaxed">
-                        {topResult.embedding_text}
-                      </code>
-                    </div>
 
                     {/* Hydrated label */}
                     <div className="flex items-center gap-2 pt-2 border-t border-gray-200">

--- a/web/src/components/VectorPipelineCard.tsx
+++ b/web/src/components/VectorPipelineCard.tsx
@@ -1,0 +1,418 @@
+import { useState, useCallback } from "react";
+import {
+  ChevronDown,
+  ChevronRight,
+  Search,
+  Zap,
+  Database,
+  ArrowRight,
+} from "lucide-react";
+import { searchApi, VectorSearchResult } from "../api/client";
+
+type StepColor = "purple" | "blue" | "green" | "orange";
+
+interface Step {
+  label: string;
+  detail: string;
+  icon: React.ComponentType<{ className?: string }>;
+  color: StepColor;
+}
+
+const STEPS: Step[] = [
+  {
+    label: "Embed query",
+    detail: "BAAI/bge-small-en-v1.5 (384-dim)",
+    icon: Zap,
+    color: "purple",
+  },
+  {
+    label: "knn_search",
+    detail: "OpenSearch finds similar order IDs",
+    icon: Search,
+    color: "blue",
+  },
+  {
+    label: "Hydrate",
+    detail: "Materialize: live status, price, ETA",
+    icon: Database,
+    color: "green",
+  },
+  {
+    label: "Merge & return",
+    detail: "Enriched result to agent",
+    icon: ArrowRight,
+    color: "orange",
+  },
+];
+
+const STEP_COLOR_CLASSES: Record<
+  StepColor,
+  { bg: string; text: string; border: string; iconBg: string }
+> = {
+  purple: {
+    bg: "bg-purple-50",
+    text: "text-purple-700",
+    border: "border-purple-200",
+    iconBg: "bg-purple-100 text-purple-600",
+  },
+  blue: {
+    bg: "bg-blue-50",
+    text: "text-blue-700",
+    border: "border-blue-200",
+    iconBg: "bg-blue-100 text-blue-600",
+  },
+  green: {
+    bg: "bg-green-50",
+    text: "text-green-700",
+    border: "border-green-200",
+    iconBg: "bg-green-100 text-green-600",
+  },
+  orange: {
+    bg: "bg-orange-50",
+    text: "text-orange-700",
+    border: "border-orange-200",
+    iconBg: "bg-orange-100 text-orange-600",
+  },
+};
+
+const STATUS_BADGE_CLASSES: Record<string, string> = {
+  OUT_FOR_DELIVERY: "bg-blue-100 text-blue-800 border-blue-300",
+  PICKING: "bg-yellow-100 text-yellow-800 border-yellow-300",
+  CREATED: "bg-gray-100 text-gray-800 border-gray-300",
+  DELIVERED: "bg-green-100 text-green-800 border-green-300",
+};
+
+const getStatusClasses = (status?: string): string => {
+  if (!status) return "bg-gray-100 text-gray-800 border-gray-300";
+  return (
+    STATUS_BADGE_CLASSES[status] || "bg-gray-100 text-gray-800 border-gray-300"
+  );
+};
+
+const formatTimeAgo = (timestamp?: string): string => {
+  if (!timestamp) return "just now";
+  const then = new Date(timestamp).getTime();
+  if (Number.isNaN(then)) return "just now";
+  const diffSec = Math.max(0, Math.floor((Date.now() - then) / 1000));
+  if (diffSec < 2) return "just now";
+  if (diffSec < 60) return `${diffSec}s ago`;
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  return `${Math.floor(diffHr / 24)}d ago`;
+};
+
+export const VectorPipelineCard = () => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [submittedQuery, setSubmittedQuery] = useState("");
+  const [isSearching, setIsSearching] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const [topResult, setTopResult] = useState<VectorSearchResult | null>(null);
+  const [hasSearched, setHasSearched] = useState(false);
+
+  const executeSearch = useCallback(async (query: string) => {
+    if (!query) {
+      setTopResult(null);
+      setSearchError(null);
+      setSubmittedQuery("");
+      setHasSearched(false);
+      return;
+    }
+
+    setIsSearching(true);
+    setSearchError(null);
+    setSubmittedQuery(query);
+    setHasSearched(true);
+
+    try {
+      const response = await searchApi.vectorSearchOrders(query, 3);
+      const first = response.data.results[0] ?? null;
+      setTopResult(first);
+    } catch (error) {
+      console.error("Vector search failed:", error);
+      setSearchError(
+        "Vector search unavailable. Ensure OpenSearch and the embedding service are running."
+      );
+      setTopResult(null);
+    } finally {
+      setIsSearching(false);
+    }
+  }, []);
+
+  const performSearch = useCallback(async () => {
+    const query = searchQuery.trim();
+    await executeSearch(query);
+  }, [searchQuery, executeSearch]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      performSearch();
+    }
+  };
+
+  const handleExampleClick = (query: string) => {
+    setSearchQuery(query);
+    executeSearch(query);
+  };
+
+  return (
+    <div className="bg-white rounded-lg shadow mb-6">
+      <button
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="w-full p-4 flex items-center justify-between hover:bg-gray-50 transition-colors"
+      >
+        <div className="flex items-center gap-2">
+          {isExpanded ? (
+            <ChevronDown className="h-5 w-5 text-gray-500" />
+          ) : (
+            <ChevronRight className="h-5 w-5 text-gray-500" />
+          )}
+          <div className="text-left">
+            <h3 className="text-lg font-semibold text-gray-900">
+              Vector Pipeline
+            </h3>
+            <p className="text-xs text-gray-500">
+              Semantic search + live data hydration from Materialize
+            </p>
+          </div>
+        </div>
+      </button>
+
+      {isExpanded && (
+        <div className="px-6 pb-6">
+          <div className="mb-4 text-sm text-gray-600 leading-relaxed">
+            <p>
+              The vector store finds <em>which</em> documents match the
+              question semantically. Materialize provides <em>live data</em>{" "}
+              for those documents&mdash;always fresh, never stale.
+            </p>
+          </div>
+
+          {/* Search input */}
+          <div className="border rounded-lg overflow-hidden mb-4">
+            <div className="bg-gray-50 px-4 py-2 border-b">
+              <div className="flex items-center gap-2">
+                <Search className="h-4 w-4 text-purple-500" />
+                <span className="text-sm font-medium text-gray-700">
+                  Ask a semantic question
+                </span>
+              </div>
+            </div>
+            <div className="p-4 space-y-3">
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder="Search by meaning (e.g., dairy products)..."
+                  className="flex-1 px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+                />
+                <button
+                  onClick={performSearch}
+                  disabled={isSearching || !searchQuery.trim()}
+                  className="px-4 py-2 bg-purple-600 text-white text-sm font-medium rounded-md hover:bg-purple-700 disabled:bg-gray-300 disabled:cursor-not-allowed flex items-center gap-2"
+                >
+                  <Search className="h-4 w-4" />
+                  Search
+                </button>
+              </div>
+
+              <div className="text-xs text-gray-500">
+                Try:{" "}
+                <button
+                  onClick={() => handleExampleClick("organic produce")}
+                  className="text-purple-600 hover:underline"
+                >
+                  organic produce
+                </button>
+                ,{" "}
+                <button
+                  onClick={() => handleExampleClick("dairy products")}
+                  className="text-purple-600 hover:underline"
+                >
+                  dairy products
+                </button>
+                ,{" "}
+                <button
+                  onClick={() => handleExampleClick("perishable delivery")}
+                  className="text-purple-600 hover:underline"
+                >
+                  perishable delivery
+                </button>
+              </div>
+            </div>
+          </div>
+
+          {/* Two-column layout */}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            {/* Left: How it works */}
+            <div className="border rounded-lg overflow-hidden">
+              <div className="bg-gray-50 px-4 py-2 border-b">
+                <span className="text-sm font-medium text-gray-700">
+                  How it works
+                </span>
+              </div>
+              <div className="p-4">
+                <ol className="space-y-2">
+                  {STEPS.map((step, idx) => {
+                    const Icon = step.icon;
+                    const colors = STEP_COLOR_CLASSES[step.color];
+                    return (
+                      <li key={step.label}>
+                        <div
+                          className={`flex items-start gap-3 p-3 rounded-md border ${colors.bg} ${colors.border}`}
+                        >
+                          <div
+                            className={`flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center ${colors.iconBg}`}
+                          >
+                            <Icon className="h-4 w-4" />
+                          </div>
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-center gap-2">
+                              <span className="text-xs font-mono text-gray-400">
+                                {idx + 1}.
+                              </span>
+                              <span
+                                className={`text-sm font-semibold ${colors.text}`}
+                              >
+                                {step.label}
+                              </span>
+                            </div>
+                            <p className="text-xs text-gray-600 mt-1">
+                              {step.detail}
+                            </p>
+                          </div>
+                        </div>
+                        {idx < STEPS.length - 1 && (
+                          <div className="flex justify-center py-1">
+                            <ArrowRight className="h-4 w-4 text-gray-400 rotate-90" />
+                          </div>
+                        )}
+                      </li>
+                    );
+                  })}
+                </ol>
+              </div>
+            </div>
+
+            {/* Right: Live order result */}
+            <div className="border rounded-lg overflow-hidden">
+              <div className="bg-gray-50 px-4 py-2 border-b flex items-center justify-between">
+                <span className="text-sm font-medium text-gray-700">
+                  Live order result
+                </span>
+                {submittedQuery && !isSearching && !searchError && (
+                  <span className="text-xs text-gray-500 font-mono truncate max-w-[60%]">
+                    "{submittedQuery}"
+                  </span>
+                )}
+              </div>
+              <div className="p-4">
+                {isSearching ? (
+                  <div className="text-sm text-gray-500 py-8 text-center">
+                    Searching...
+                  </div>
+                ) : searchError ? (
+                  <div className="text-sm text-red-600 py-8 text-center">
+                    {searchError}
+                  </div>
+                ) : !hasSearched ? (
+                  <div className="text-sm text-gray-400 py-8 text-center italic">
+                    Enter a query to see a live result...
+                  </div>
+                ) : !topResult ? (
+                  <div className="text-sm text-gray-500 py-8 text-center">
+                    No results found.
+                  </div>
+                ) : (
+                  <div className="space-y-3">
+                    {/* Order header */}
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        <span className="text-base font-bold text-gray-900">
+                          {topResult.order_number
+                            ? `#${topResult.order_number}`
+                            : topResult.order_id}
+                        </span>
+                        {topResult.order_status && (
+                          <span
+                            className={`px-2 py-0.5 text-xs font-medium rounded border ${getStatusClasses(
+                              topResult.order_status
+                            )}`}
+                          >
+                            {topResult.order_status}
+                          </span>
+                        )}
+                      </div>
+                      <span className="text-xs text-purple-700 font-semibold">
+                        {(topResult.score * 100).toFixed(1)}% match
+                      </span>
+                    </div>
+
+                    {/* Customer */}
+                    {topResult.customer_name && (
+                      <div className="text-sm">
+                        <span className="text-gray-500">Customer: </span>
+                        <span className="font-medium text-gray-900">
+                          {topResult.customer_name}
+                        </span>
+                      </div>
+                    )}
+
+                    {/* Store + zone */}
+                    {(topResult.store_name || topResult.store_zone) && (
+                      <div className="text-sm">
+                        <span className="text-gray-500">Store: </span>
+                        <span className="font-medium text-gray-900">
+                          {topResult.store_name}
+                          {topResult.store_zone &&
+                            ` (${topResult.store_zone})`}
+                        </span>
+                      </div>
+                    )}
+
+                    {/* Total */}
+                    {typeof topResult.order_total_amount === "number" && (
+                      <div className="text-sm">
+                        <span className="text-gray-500">Total: </span>
+                        <span className="font-medium text-gray-900">
+                          ${topResult.order_total_amount.toFixed(2)}
+                        </span>
+                      </div>
+                    )}
+
+                    {/* Embedding text */}
+                    <div className="pt-2 border-t border-gray-200">
+                      <div className="text-xs text-gray-500 mb-1">
+                        Embedded text
+                      </div>
+                      <code className="block bg-gray-100 text-xs font-mono text-gray-800 px-2 py-1.5 rounded break-words">
+                        {topResult.embedding_text}
+                      </code>
+                    </div>
+
+                    {/* Hydrated label */}
+                    <div className="flex items-center gap-2 pt-2 border-t border-gray-200">
+                      <Database className="h-3.5 w-3.5 text-green-600" />
+                      <span className="text-xs font-medium text-green-700">
+                        Hydrated from Materialize
+                      </span>
+                      <span className="text-xs text-gray-500 ml-auto">
+                        {formatTimeAgo(topResult.effective_updated_at)}
+                      </span>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default VectorPipelineCard;

--- a/web/src/components/VectorPipelineCard.tsx
+++ b/web/src/components/VectorPipelineCard.tsx
@@ -108,13 +108,10 @@ interface ResultCardProps {
   embeddingFlashing: boolean;
 }
 
-const ResultCard = ({ result, rank, flashedRows, embeddingFlashing }: ResultCardProps) => (
+const ResultCard = ({ result, rank: _rank, flashedRows, embeddingFlashing }: ResultCardProps) => (
   <div className="space-y-1.5">
     {/* Header row */}
     <div className="flex items-center gap-2 flex-wrap">
-      <span className="flex-shrink-0 w-5 h-5 rounded-full bg-purple-100 text-purple-700 text-xs font-bold flex items-center justify-center">
-        {rank}
-      </span>
       <span className="font-semibold text-gray-900 text-sm">#{result.order_number ?? result.order_id}</span>
       {result.order_status && (
         <span className={`px-1.5 py-0.5 text-xs font-medium rounded border ${getStatusClasses(result.order_status)}`}>
@@ -130,7 +127,7 @@ const ResultCard = ({ result, rank, flashedRows, embeddingFlashing }: ResultCard
       </span>
     </div>
 
-    {/* Embedding strip */}
+    {/* Embedding strip + text */}
     <div className="flex items-center gap-2">
       <div className="flex-1">
         <EmbeddingStrip vector={result.embedding} flashing={embeddingFlashing} height={12} />
@@ -141,6 +138,11 @@ const ResultCard = ({ result, rank, flashedRows, embeddingFlashing }: ResultCard
           : `emb ${fmtTime(result.embedded_at)}`}
       </span>
     </div>
+    {result.embedding_text && (
+      <code className="block bg-gray-100 text-xs font-mono text-gray-600 px-2 py-1 rounded break-words leading-relaxed">
+        {result.embedding_text}
+      </code>
+    )}
 
     {/* Line items */}
     {result.line_items && result.line_items.length > 0 && (
@@ -196,10 +198,8 @@ const ResultCard = ({ result, rank, flashedRows, embeddingFlashing }: ResultCard
 
     {/* Footer */}
     <div className="flex items-center gap-1.5">
-      <Database className="h-3 w-3 text-green-500" />
-      <span className="text-xs text-green-700">Hydrated</span>
       {result.order_total_amount != null && (
-        <span className="text-xs text-gray-500">· Total: ${parseFloat(String(result.order_total_amount)).toFixed(2)}</span>
+        <span className="text-xs text-gray-500">Total: ${parseFloat(String(result.order_total_amount)).toFixed(2)}</span>
       )}
       <span className="text-xs text-gray-400 ml-auto">{fmtAgo(result.effective_updated_at)}</span>
     </div>
@@ -357,6 +357,11 @@ export const VectorPipelineCard = () => {
             </div>
           </div>
 
+          {/* Write a Triple */}
+          <div className="mb-4">
+            <WriteTripleForm />
+          </div>
+
           {/* Two-column layout */}
           <div className="grid grid-cols-1 lg:grid-cols-[280px_1fr] gap-4">
             {/* Left: How it works */}
@@ -440,10 +445,7 @@ export const VectorPipelineCard = () => {
             </div>
           </div>
 
-          {/* Write a Triple — full-width row */}
-          <div className="mt-4">
-            <WriteTripleForm />
-          </div>
+
         </div>
       )}
     </div>

--- a/web/src/components/VectorPipelineCard.tsx
+++ b/web/src/components/VectorPipelineCard.tsx
@@ -9,6 +9,7 @@ import {
   RefreshCw,
 } from "lucide-react";
 import { searchApi, VectorSearchResult, VectorLineItem } from "../api/client";
+import { WriteTripleForm } from "./WriteTripleForm";
 
 // ── Embedding strip ──────────────────────────────────────────────────────────
 // Downsample a 384-dim vector to `bands` colour blocks and render them as an
@@ -236,7 +237,7 @@ export const VectorPipelineCard = () => {
               <div className="bg-gray-50 px-4 py-2 border-b">
                 <span className="text-sm font-medium text-gray-700">How it works</span>
               </div>
-              <div className="p-4">
+              <div className="p-4 space-y-4">
                 <ol className="space-y-2">
                   {STEPS.map((step, idx) => {
                     const c = STEP_COLORS[step.color];
@@ -264,6 +265,7 @@ export const VectorPipelineCard = () => {
                     );
                   })}
                 </ol>
+                <WriteTripleForm />
               </div>
             </div>
 

--- a/web/src/components/VectorPipelineCard.tsx
+++ b/web/src/components/VectorPipelineCard.tsx
@@ -3,9 +3,6 @@ import {
   ChevronDown,
   ChevronRight,
   Search,
-  Zap,
-  Database,
-  ArrowRight,
   RefreshCw,
 } from "lucide-react";
 import { searchApi, VectorSearchResult, VectorLineItem } from "../api/client";
@@ -79,24 +76,6 @@ const fmtAgo = (iso?: string | null): string => {
   if (sec < 60) return `${sec}s ago`;
   if (sec < 3600) return `${Math.floor(sec / 60)}m ago`;
   return `${Math.floor(sec / 3600)}h ago`;
-};
-
-// ── Architecture steps ───────────────────────────────────────────────────────
-
-type StepColor = "purple" | "blue" | "green" | "orange";
-
-const STEPS = [
-  { label: "Embed query",    detail: "BAAI/bge-small-en-v1.5 (384-dim)",    color: "purple" as StepColor, icon: Zap },
-  { label: "knn_search",     detail: "OpenSearch returns top-N order IDs",   color: "blue"   as StepColor, icon: Search },
-  { label: "Hydrate",        detail: "Materialize: live status, price, ETA", color: "green"  as StepColor, icon: Database },
-  { label: "Merge & return", detail: "Enriched result to agent",             color: "orange" as StepColor, icon: ArrowRight },
-];
-
-const STEP_COLORS: Record<StepColor, { bg: string; text: string; border: string; icon: string }> = {
-  purple: { bg: "bg-purple-50", text: "text-purple-700", border: "border-purple-200", icon: "bg-purple-100 text-purple-600" },
-  blue:   { bg: "bg-blue-50",   text: "text-blue-700",   border: "border-blue-200",   icon: "bg-blue-100 text-blue-600" },
-  green:  { bg: "bg-green-50",  text: "text-green-700",  border: "border-green-200",  icon: "bg-green-100 text-green-600" },
-  orange: { bg: "bg-orange-50", text: "text-orange-700", border: "border-orange-200", icon: "bg-orange-100 text-orange-600" },
 };
 
 // ── Compact result card ───────────────────────────────────────────────────────
@@ -371,87 +350,49 @@ export const VectorPipelineCard = () => {
             <WriteTripleForm initialSubject={writeSubject} />
           </div>
 
-          {/* Two-column layout */}
-          <div className="grid grid-cols-1 lg:grid-cols-[280px_1fr] gap-4">
-            {/* Left: How it works */}
-            <div className="border rounded-lg overflow-hidden">
-              <div className="bg-gray-50 px-4 py-2 border-b">
-                <span className="text-sm font-medium text-gray-700">How it works</span>
-              </div>
-              <div className="p-3">
-                <ol className="flex flex-col gap-0">
-                  {STEPS.map((step, idx) => {
-                    const c = STEP_COLORS[step.color];
-                    const Icon = step.icon;
-                    return (
-                      <li key={step.label} className="flex flex-col">
-                        <div className={`flex items-center gap-2 px-2 py-1.5 rounded border ${c.bg} ${c.border}`}>
-                          <div className={`flex-shrink-0 w-6 h-6 rounded-full flex items-center justify-center ${c.icon}`}>
-                            <Icon className="h-3 w-3" />
-                          </div>
-                          <div className="flex items-baseline gap-1.5 min-w-0">
-                            <span className="text-xs font-mono text-gray-400">{idx + 1}.</span>
-                            <span className={`text-xs font-semibold ${c.text}`}>{step.label}</span>
-                            <span className="text-xs text-gray-500 truncate">{step.detail}</span>
-                          </div>
-                        </div>
-                        {idx < STEPS.length - 1 && (
-                          <div className="flex justify-center py-0.5">
-                            <ArrowRight className="h-3 w-3 text-gray-300 rotate-90" />
-                          </div>
-                        )}
-                      </li>
-                    );
-                  })}
-                </ol>
-              </div>
-            </div>
-
-            {/* Right: Live order results */}
-            <div className="border rounded-lg overflow-hidden">
-              <div className="bg-gray-50 px-4 py-2 border-b flex items-center justify-between">
-                <span className="text-sm font-medium text-gray-700">
-                  Live order results
-                  {results.length > 0 && <span className="ml-1.5 text-xs text-gray-400 font-normal">top {results.length} by relevance</span>}
-                </span>
-                <div className="flex items-center gap-2">
-                  {lastRefresh && (
-                    <span className="text-xs text-gray-400 flex items-center gap-1">
-                      <RefreshCw className="h-3 w-3" />
-                      {fmtAgo(lastRefresh.toISOString())}
-                    </span>
-                  )}
-                  {submittedQuery && !isSearching && !searchError && (
-                    <span className="text-xs text-gray-500 font-mono truncate max-w-[120px]">"{submittedQuery}"</span>
-                  )}
-                </div>
-              </div>
-
-              <div className="p-4">
-                {isSearching ? (
-                  <div className="text-sm text-gray-500 py-8 text-center">Searching...</div>
-                ) : searchError ? (
-                  <div className="text-sm text-red-600 py-8 text-center">{searchError}</div>
-                ) : !hasSearched ? (
-                  <div className="text-sm text-gray-400 py-8 text-center italic">Enter a query to see live results...</div>
-                ) : results.length === 0 ? (
-                  <div className="text-sm text-gray-500 py-8 text-center">No results found.</div>
-                ) : (
-                  <div className="divide-y divide-gray-100">
-                    {results.map((result, idx) => (
-                      <div key={result.order_id} className={idx > 0 ? "pt-3 mt-3" : ""}>
-                        <ResultCard
-                          result={result}
-                          rank={idx + 1}
-                          flashedRows={flashedRowsByResult[idx] ?? new Set()}
-                          embeddingFlashing={flashedEmbeddings.has(idx)}
-                          onSelectSubject={setWriteSubject}
-                        />
-                      </div>
-                    ))}
-                  </div>
+          {/* Live order results */}
+          <div className="border rounded-lg overflow-hidden">
+            <div className="bg-gray-50 px-4 py-2 border-b flex items-center justify-between">
+              <span className="text-sm font-medium text-gray-700">
+                Live order results
+                {results.length > 0 && <span className="ml-1.5 text-xs text-gray-400 font-normal">top {results.length} by relevance</span>}
+              </span>
+              <div className="flex items-center gap-2">
+                {lastRefresh && (
+                  <span className="text-xs text-gray-400 flex items-center gap-1">
+                    <RefreshCw className="h-3 w-3" />
+                    {fmtAgo(lastRefresh.toISOString())}
+                  </span>
+                )}
+                {submittedQuery && !isSearching && !searchError && (
+                  <span className="text-xs text-gray-500 font-mono truncate max-w-[120px]">"{submittedQuery}"</span>
                 )}
               </div>
+            </div>
+            <div className="p-4">
+              {isSearching ? (
+                <div className="text-sm text-gray-500 py-8 text-center">Searching...</div>
+              ) : searchError ? (
+                <div className="text-sm text-red-600 py-8 text-center">{searchError}</div>
+              ) : !hasSearched ? (
+                <div className="text-sm text-gray-400 py-8 text-center italic">Enter a query to see live results...</div>
+              ) : results.length === 0 ? (
+                <div className="text-sm text-gray-500 py-8 text-center">No results found.</div>
+              ) : (
+                <div className="divide-y divide-gray-100">
+                  {results.map((result, idx) => (
+                    <div key={result.order_id} className={idx > 0 ? "pt-3 mt-3" : ""}>
+                      <ResultCard
+                        result={result}
+                        rank={idx + 1}
+                        flashedRows={flashedRowsByResult[idx] ?? new Set()}
+                        embeddingFlashing={flashedEmbeddings.has(idx)}
+                        onSelectSubject={setWriteSubject}
+                      />
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
           </div>
 

--- a/web/src/components/VectorPipelineCard.tsx
+++ b/web/src/components/VectorPipelineCard.tsx
@@ -242,7 +242,7 @@ export const VectorPipelineCard = () => {
         ...(filterStatus ? { order_status: filterStatus } : {}),
       };
       const response = await searchApi.vectorSearchOrders(query, 5, filters);
-      applyResults(response.data.results ?? []);
+      applyResults((response.data.results ?? []).filter(r => r.score >= 0.6));
     } catch (err) {
       if (!silent) {
         console.error("Vector search failed:", err);
@@ -297,7 +297,7 @@ export const VectorPipelineCard = () => {
           <div className="border rounded-lg overflow-hidden mb-4">
             <div className="bg-gray-50 px-4 py-2 border-b flex items-center gap-2">
               <Search className="h-4 w-4 text-purple-500" />
-              <span className="text-sm font-medium text-gray-700">Semantic Search</span>
+              <span className="text-sm font-medium text-gray-700">Hybrid Search</span>
             </div>
             <div className="p-4 space-y-3">
               <div className="flex gap-2">

--- a/web/src/components/WriteTripleForm.tsx
+++ b/web/src/components/WriteTripleForm.tsx
@@ -1,6 +1,23 @@
 import { useState, useEffect, useMemo } from "react";
 import { Edit3 } from "lucide-react";
 import { queryStatsApi, searchApi } from "../api/client";
+import { usePropagation } from "../contexts/PropagationContext";
+
+const VIRTUAL_SIZE = 65536; // large space so marks are proportionally sparse
+
+function hashDocId(id: string): number {
+  let h = 0;
+  for (let i = 0; i < id.length; i++) {
+    h = Math.imul(31, h) + id.charCodeAt(i) >>> 0;
+  }
+  return h % VIRTUAL_SIZE;
+}
+
+const OP_COLORS: Record<string, string> = {
+  INSERT: '#10b981',
+  UPDATE: '#a855f7',
+  DELETE: '#ef4444',
+};
 
 const predicatesBySubjectType: Record<string, string[]> = {
   order: ['order_status', 'order_number', 'delivery_window_start', 'delivery_window_end'],
@@ -38,8 +55,33 @@ export const WriteTripleForm = ({ initialSubject = "", onWritten }: WriteTripleF
   const [status, setStatus]       = useState<string | null>(null);
   const [impact, setImpact]       = useState<{ impacted: number; total: number; pct: number } | null>(null);
   const [watchingImpact, setWatchingImpact] = useState(false);
+  const [writeTimestamp, setWriteTimestamp] = useState<number | null>(null);
+
+  const { events } = usePropagation();
+
+  // Marks: one per unique doc_id changed since last write, at a proportional position
+  const marks = useMemo(() => {
+    if (!writeTimestamp) return null;
+    const relevant = events.filter((e) => e.timestamp >= writeTimestamp);
+    if (relevant.length === 0) return null;
+    const seen = new Map<string, string>(); // doc_id → color
+    for (const e of relevant) {
+      seen.set(e.doc_id, OP_COLORS[e.operation] ?? '#6b7280');
+    }
+    return Array.from(seen.entries()).map(([doc_id, color]) => ({
+      doc_id,
+      color,
+      pct: (hashDocId(doc_id) / VIRTUAL_SIZE) * 100,
+    }));
+  }, [events, writeTimestamp]);
 
   useEffect(() => { setSubject(initialSubject); }, [initialSubject]);
+
+  // Clear impact + buckets whenever the user starts a new search
+  useEffect(() => {
+    setImpact(null);
+    setWriteTimestamp(null);
+  }, [subject, predicate, value]);
 
   const availablePredicates = useMemo(() => {
     let base = predicatesBySubjectType.orderline;
@@ -87,8 +129,10 @@ export const WriteTripleForm = ({ initialSubject = "", onWritten }: WriteTripleF
       flash("Error: Subject should be 'type:id' or 'type_id'"); return;
     }
     setImpact(null);
+    setWriteTimestamp(null);
     try {
       const res = await queryStatsApi.writeTriple({ subject_id: subject, predicate, object_value: value });
+      setWriteTimestamp(Date.now() / 1000); // seconds to match PropagationEvent.timestamp
       flash(`Written at ${new Date().toLocaleTimeString()}`);
       onWritten?.();
       if (res.data.mz_timestamp_lower_bound != null) {
@@ -158,23 +202,42 @@ export const WriteTripleForm = ({ initialSubject = "", onWritten }: WriteTripleF
           </span>
         )}
       </div>
-      {(watchingImpact || impact) && (
-        <div className="mt-2 text-xs text-gray-600 flex items-center gap-1.5">
-          {watchingImpact && !impact && (
-            <span className="text-gray-400 animate-pulse">Watching pipeline...</span>
-          )}
-          {impact && (
-            <>
-              <span className="font-mono text-purple-700 font-semibold">{impact.impacted}</span>
-              <span className="text-gray-400">/</span>
-              <span className="font-mono text-gray-600">{impact.total}</span>
-              <span className="text-gray-500">docs re-indexed</span>
-              <span className={`font-semibold ml-1 ${impact.pct > 10 ? 'text-orange-600' : 'text-purple-600'}`}>
-                ({impact.pct}%)
-              </span>
-              {watchingImpact && <span className="text-gray-400 animate-pulse ml-1">…</span>}
-            </>
-          )}
+      {(watchingImpact || marks || impact) && (
+        <div className="mt-3">
+          {/* Proportional marker bar */}
+          <div className="relative h-4 rounded overflow-hidden bg-gray-200">
+            {marks?.map(({ doc_id, color, pct }) => (
+              <div
+                key={doc_id}
+                className="absolute top-0 bottom-0"
+                style={{ left: `${pct}%`, width: '2px', backgroundColor: color }}
+                title={doc_id}
+              />
+            ))}
+          </div>
+          {/* Count row */}
+          <div className="mt-1 text-xs text-gray-500 flex items-center gap-2">
+            {watchingImpact && !impact && (
+              <span className="text-gray-400 animate-pulse">Watching pipeline…</span>
+            )}
+            {impact && (
+              <>
+                <span className="font-mono font-semibold text-purple-700">{impact.impacted}</span>
+                <span className="text-gray-400">/</span>
+                <span className="font-mono text-gray-600">{impact.total}</span>
+                <span>docs re-indexed</span>
+                <span className={`font-semibold ${impact.pct > 10 ? 'text-orange-600' : 'text-purple-600'}`}>
+                  ({impact.pct}%)
+                </span>
+                {watchingImpact && <span className="text-gray-400 animate-pulse">…</span>}
+              </>
+            )}
+            <div className="ml-auto flex items-center gap-3 text-gray-400">
+              <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm" style={{ backgroundColor: OP_COLORS.INSERT }} />insert</span>
+              <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm" style={{ backgroundColor: OP_COLORS.UPDATE }} />update</span>
+              <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm" style={{ backgroundColor: OP_COLORS.DELETE }} />delete</span>
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/web/src/components/WriteTripleForm.tsx
+++ b/web/src/components/WriteTripleForm.tsx
@@ -1,0 +1,140 @@
+import { useState, useEffect, useMemo } from "react";
+import { Edit3 } from "lucide-react";
+import { queryStatsApi } from "../api/client";
+
+const predicatesBySubjectType: Record<string, string[]> = {
+  order: ['order_status', 'order_number', 'delivery_window_start', 'delivery_window_end'],
+  orderline: ['quantity', 'order_line_unit_price', 'line_sequence'],
+  customer: ['customer_name', 'customer_email', 'customer_address'],
+  store: ['store_name', 'store_zone', 'store_address'],
+  product: ['product_name', 'category', 'unit_price', 'perishable', 'unit_weight_grams'],
+  inventory: ['stock_level', 'replenishment_eta'],
+  courier: ['courier_name', 'courier_phone', 'courier_status'],
+  task: ['task_status', 'assigned_to', 'eta'],
+};
+
+const placeholdersByPredicate: Record<string, string> = {
+  order_status: 'DELIVERED', order_number: 'FM-1234',
+  delivery_window_start: '2025-01-15T10:00:00', delivery_window_end: '2025-01-15T12:00:00',
+  quantity: '5', order_line_unit_price: '12.99', line_sequence: '1',
+  customer_name: 'John Doe', customer_email: 'john@example.com', customer_address: '123 Main St',
+  store_name: 'Downtown Market', store_zone: 'MAN', store_address: '456 Broadway',
+  product_name: 'Organic Apples', category: 'Produce', unit_price: '4.99',
+  perishable: 'true', unit_weight_grams: '500',
+  stock_level: '100', replenishment_eta: '2025-01-16T08:00:00',
+  courier_name: 'Jane Smith', courier_phone: '555-1234', courier_status: 'ACTIVE',
+  task_status: 'COMPLETED', assigned_to: 'courier:C-001', eta: '2025-01-15T11:00:00',
+};
+
+interface WriteTripleFormProps {
+  initialSubject?: string;
+  onWritten?: () => void;
+}
+
+export const WriteTripleForm = ({ initialSubject = "", onWritten }: WriteTripleFormProps) => {
+  const [subject, setSubject]     = useState(initialSubject);
+  const [predicate, setPredicate] = useState("quantity");
+  const [value, setValue]         = useState("");
+  const [status, setStatus]       = useState<string | null>(null);
+
+  useEffect(() => { setSubject(initialSubject); }, [initialSubject]);
+
+  const availablePredicates = useMemo(() => {
+    let base = predicatesBySubjectType.orderline;
+    if (subject) {
+      const colonIdx = subject.indexOf(':');
+      const prefix = colonIdx > -1
+        ? subject.slice(0, colonIdx).toLowerCase()
+        : subject.includes('_') ? subject.split('_')[0].toLowerCase() : '';
+      if (prefix) base = predicatesBySubjectType[prefix] ?? predicatesBySubjectType.orderline;
+    }
+    return predicate && !base.includes(predicate) ? [predicate, ...base] : base;
+  }, [subject, predicate]);
+
+  useEffect(() => {
+    if (availablePredicates.length > 0 && !availablePredicates.includes(predicate)) {
+      setPredicate(availablePredicates[0]);
+    }
+  }, [availablePredicates, predicate]);
+
+  const handleWrite = async () => {
+    if (!subject || !predicate || !value) return;
+    if (subject.length > 255) { flash("Error: Subject too long"); return; }
+    if (predicate.length > 255) { flash("Error: Predicate too long"); return; }
+    if (value.length > 1000) { flash("Error: Value too long"); return; }
+    if (!subject.includes(':') && !subject.includes('_')) {
+      flash("Error: Subject should be 'type:id' or 'type_id'"); return;
+    }
+    try {
+      await queryStatsApi.writeTriple({ subject_id: subject, predicate, object_value: value });
+      flash(`Written at ${new Date().toLocaleTimeString()}`);
+      onWritten?.();
+    } catch {
+      flash("Write failed");
+    }
+  };
+
+  const flash = (msg: string) => {
+    setStatus(msg);
+    setTimeout(() => setStatus(null), 3000);
+  };
+
+  return (
+    <div className="bg-gray-50 rounded-lg p-4">
+      <div className="flex items-center gap-2 mb-3">
+        <Edit3 className="h-4 w-4 text-purple-600" />
+        <span className="font-medium text-gray-900">Write a Triple</span>
+        <span className="text-xs text-gray-500">— Update an order property and observe propagation</span>
+      </div>
+
+      <div className="flex items-end gap-3 flex-wrap">
+        <div className="flex-1 min-w-[120px]">
+          <label className="block text-xs font-medium text-gray-600 mb-1">Subject</label>
+          <input
+            type="text"
+            value={subject}
+            onChange={e => setSubject(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm text-sm focus:outline-none focus:ring-purple-500 focus:border-purple-500 bg-white"
+            placeholder="order:FM-1001"
+          />
+        </div>
+        <div className="flex-1 min-w-[120px]">
+          <label className="block text-xs font-medium text-gray-600 mb-1">Predicate</label>
+          <select
+            value={predicate}
+            onChange={e => setPredicate(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm text-sm focus:outline-none focus:ring-purple-500 focus:border-purple-500 bg-white"
+          >
+            {availablePredicates.map(p => <option key={p} value={p}>{p}</option>)}
+          </select>
+        </div>
+        <div className="flex-1 min-w-[120px]">
+          <label className="block text-xs font-medium text-gray-600 mb-1">Value</label>
+          <input
+            type="text"
+            value={value}
+            onChange={e => setValue(e.target.value)}
+            onKeyDown={e => { if (e.key === 'Enter') handleWrite(); }}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm text-sm focus:outline-none focus:ring-purple-500 focus:border-purple-500 bg-white"
+            placeholder={placeholdersByPredicate[predicate] || 'value'}
+          />
+        </div>
+        <button
+          onClick={handleWrite}
+          disabled={!subject || !predicate || !value}
+          className="px-4 py-2 bg-purple-600 text-white rounded-md hover:bg-purple-700 disabled:bg-gray-400 disabled:cursor-not-allowed text-sm"
+        >
+          Write
+        </button>
+        {status && (
+          <span className={`text-sm flex items-center gap-1 ${status.startsWith('Error') ? 'text-red-600' : 'text-green-600'}`}>
+            <span className={`inline-block w-2 h-2 rounded-full ${status.startsWith('Error') ? 'bg-red-500' : 'bg-green-500'}`} />
+            {status}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default WriteTripleForm;

--- a/web/src/components/WriteTripleForm.tsx
+++ b/web/src/components/WriteTripleForm.tsx
@@ -1,23 +1,6 @@
 import { useState, useEffect, useMemo } from "react";
 import { Edit3 } from "lucide-react";
-import { queryStatsApi, searchApi } from "../api/client";
-import { usePropagation } from "../contexts/PropagationContext";
-
-const VIRTUAL_SIZE = 65536; // large space so marks are proportionally sparse
-
-function hashDocId(id: string): number {
-  let h = 0;
-  for (let i = 0; i < id.length; i++) {
-    h = Math.imul(31, h) + id.charCodeAt(i) >>> 0;
-  }
-  return h % VIRTUAL_SIZE;
-}
-
-const OP_COLORS: Record<string, string> = {
-  INSERT: '#10b981',
-  UPDATE: '#a855f7',
-  DELETE: '#ef4444',
-};
+import { queryStatsApi } from "../api/client";
 
 const predicatesBySubjectType: Record<string, string[]> = {
   order: ['order_status', 'order_number', 'delivery_window_start', 'delivery_window_end'],
@@ -46,42 +29,16 @@ const placeholdersByPredicate: Record<string, string> = {
 interface WriteTripleFormProps {
   initialSubject?: string;
   onWritten?: () => void;
+  onWriteComplete?: (mzLowerBound: number, wallClock: number) => void;
 }
 
-export const WriteTripleForm = ({ initialSubject = "", onWritten }: WriteTripleFormProps) => {
+export const WriteTripleForm = ({ initialSubject = "", onWritten, onWriteComplete }: WriteTripleFormProps) => {
   const [subject, setSubject]     = useState(initialSubject);
   const [predicate, setPredicate] = useState("quantity");
   const [value, setValue]         = useState("");
   const [status, setStatus]       = useState<string | null>(null);
-  const [impact, setImpact]       = useState<{ impacted: number; total: number; pct: number } | null>(null);
-  const [watchingImpact, setWatchingImpact] = useState(false);
-  const [writeTimestamp, setWriteTimestamp] = useState<number | null>(null);
-
-  const { events } = usePropagation();
-
-  // Marks: one per unique doc_id changed since last write, at a proportional position
-  const marks = useMemo(() => {
-    if (!writeTimestamp) return null;
-    const relevant = events.filter((e) => e.timestamp >= writeTimestamp);
-    if (relevant.length === 0) return null;
-    const seen = new Map<string, string>(); // doc_id → color
-    for (const e of relevant) {
-      seen.set(e.doc_id, OP_COLORS[e.operation] ?? '#6b7280');
-    }
-    return Array.from(seen.entries()).map(([doc_id, color]) => ({
-      doc_id,
-      color,
-      pct: (hashDocId(doc_id) / VIRTUAL_SIZE) * 100,
-    }));
-  }, [events, writeTimestamp]);
 
   useEffect(() => { setSubject(initialSubject); }, [initialSubject]);
-
-  // Clear impact + buckets whenever the user starts a new search
-  useEffect(() => {
-    setImpact(null);
-    setWriteTimestamp(null);
-  }, [subject, predicate, value]);
 
   const availablePredicates = useMemo(() => {
     let base = predicatesBySubjectType.orderline;
@@ -101,25 +58,6 @@ export const WriteTripleForm = ({ initialSubject = "", onWritten }: WriteTripleF
     }
   }, [availablePredicates, predicate]);
 
-  const watchImpact = async (lowerBound: number) => {
-    setWatchingImpact(true);
-    setImpact(null);
-    let lastImpacted = -1;
-    for (let i = 0; i < 8; i++) {
-      await new Promise(r => setTimeout(r, 1000));
-      try {
-        const res = await searchApi.indexImpact(lowerBound);
-        const data = res.data;
-        if (data.impacted > 0 && data.impacted === lastImpacted) break;
-        lastImpacted = data.impacted;
-        setImpact(data);
-      } catch {
-        break;
-      }
-    }
-    setWatchingImpact(false);
-  };
-
   const handleWrite = async () => {
     if (!subject || !predicate || !value) return;
     if (subject.length > 255) { flash("Error: Subject too long"); return; }
@@ -128,15 +66,12 @@ export const WriteTripleForm = ({ initialSubject = "", onWritten }: WriteTripleF
     if (!subject.includes(':') && !subject.includes('_')) {
       flash("Error: Subject should be 'type:id' or 'type_id'"); return;
     }
-    setImpact(null);
-    setWriteTimestamp(null);
     try {
       const res = await queryStatsApi.writeTriple({ subject_id: subject, predicate, object_value: value });
-      setWriteTimestamp(Date.now() / 1000); // seconds to match PropagationEvent.timestamp
       flash(`Written at ${new Date().toLocaleTimeString()}`);
       onWritten?.();
       if (res.data.mz_timestamp_lower_bound != null) {
-        watchImpact(res.data.mz_timestamp_lower_bound);
+        onWriteComplete?.(res.data.mz_timestamp_lower_bound, Date.now() / 1000);
       }
     } catch {
       flash("Write failed");
@@ -202,44 +137,6 @@ export const WriteTripleForm = ({ initialSubject = "", onWritten }: WriteTripleF
           </span>
         )}
       </div>
-      <div className="mt-3">
-          {/* Proportional marker bar — always visible, markers fill in after write */}
-          <div className="relative h-4 rounded overflow-hidden bg-gray-200">
-            {marks?.map(({ doc_id, color, pct }) => (
-              <div
-                key={doc_id}
-                className="absolute top-0 bottom-0"
-                style={{ left: `${pct}%`, width: '2px', backgroundColor: color }}
-                title={doc_id}
-              />
-            ))}
-          </div>
-          {/* Count row — only shown after a write */}
-          {(watchingImpact || impact) && (
-          <div className="mt-1 text-xs text-gray-500 flex items-center gap-2">
-            {watchingImpact && !impact && (
-              <span className="text-gray-400 animate-pulse">Watching pipeline…</span>
-            )}
-            {impact && (
-              <>
-                <span className="font-mono font-semibold text-purple-700">{impact.impacted}</span>
-                <span className="text-gray-400">/</span>
-                <span className="font-mono text-gray-600">{impact.total}</span>
-                <span>docs re-indexed</span>
-                <span className={`font-semibold ${impact.pct > 10 ? 'text-orange-600' : 'text-purple-600'}`}>
-                  ({impact.pct}%)
-                </span>
-                {watchingImpact && <span className="text-gray-400 animate-pulse">…</span>}
-              </>
-            )}
-            <div className="ml-auto flex items-center gap-3 text-gray-400">
-              <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm" style={{ backgroundColor: OP_COLORS.INSERT }} />insert</span>
-              <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm" style={{ backgroundColor: OP_COLORS.UPDATE }} />update</span>
-              <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm" style={{ backgroundColor: OP_COLORS.DELETE }} />delete</span>
-            </div>
-          </div>
-          )}
-        </div>
     </div>
   );
 };

--- a/web/src/components/WriteTripleForm.tsx
+++ b/web/src/components/WriteTripleForm.tsx
@@ -202,9 +202,8 @@ export const WriteTripleForm = ({ initialSubject = "", onWritten }: WriteTripleF
           </span>
         )}
       </div>
-      {(watchingImpact || marks || impact) && (
-        <div className="mt-3">
-          {/* Proportional marker bar */}
+      <div className="mt-3">
+          {/* Proportional marker bar — always visible, markers fill in after write */}
           <div className="relative h-4 rounded overflow-hidden bg-gray-200">
             {marks?.map(({ doc_id, color, pct }) => (
               <div
@@ -215,7 +214,8 @@ export const WriteTripleForm = ({ initialSubject = "", onWritten }: WriteTripleF
               />
             ))}
           </div>
-          {/* Count row */}
+          {/* Count row — only shown after a write */}
+          {(watchingImpact || impact) && (
           <div className="mt-1 text-xs text-gray-500 flex items-center gap-2">
             {watchingImpact && !impact && (
               <span className="text-gray-400 animate-pulse">Watching pipeline…</span>
@@ -238,8 +238,8 @@ export const WriteTripleForm = ({ initialSubject = "", onWritten }: WriteTripleF
               <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm" style={{ backgroundColor: OP_COLORS.DELETE }} />delete</span>
             </div>
           </div>
+          )}
         </div>
-      )}
     </div>
   );
 };

--- a/web/src/components/WriteTripleForm.tsx
+++ b/web/src/components/WriteTripleForm.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from "react";
 import { Edit3 } from "lucide-react";
-import { queryStatsApi } from "../api/client";
+import { queryStatsApi, searchApi } from "../api/client";
 
 const predicatesBySubjectType: Record<string, string[]> = {
   order: ['order_status', 'order_number', 'delivery_window_start', 'delivery_window_end'],
@@ -36,6 +36,8 @@ export const WriteTripleForm = ({ initialSubject = "", onWritten }: WriteTripleF
   const [predicate, setPredicate] = useState("quantity");
   const [value, setValue]         = useState("");
   const [status, setStatus]       = useState<string | null>(null);
+  const [impact, setImpact]       = useState<{ impacted: number; total: number; pct: number } | null>(null);
+  const [watchingImpact, setWatchingImpact] = useState(false);
 
   useEffect(() => { setSubject(initialSubject); }, [initialSubject]);
 
@@ -57,6 +59,25 @@ export const WriteTripleForm = ({ initialSubject = "", onWritten }: WriteTripleF
     }
   }, [availablePredicates, predicate]);
 
+  const watchImpact = async (lowerBound: number) => {
+    setWatchingImpact(true);
+    setImpact(null);
+    let lastImpacted = -1;
+    for (let i = 0; i < 8; i++) {
+      await new Promise(r => setTimeout(r, 1000));
+      try {
+        const res = await searchApi.indexImpact(lowerBound);
+        const data = res.data;
+        if (data.impacted > 0 && data.impacted === lastImpacted) break;
+        lastImpacted = data.impacted;
+        setImpact(data);
+      } catch {
+        break;
+      }
+    }
+    setWatchingImpact(false);
+  };
+
   const handleWrite = async () => {
     if (!subject || !predicate || !value) return;
     if (subject.length > 255) { flash("Error: Subject too long"); return; }
@@ -65,10 +86,14 @@ export const WriteTripleForm = ({ initialSubject = "", onWritten }: WriteTripleF
     if (!subject.includes(':') && !subject.includes('_')) {
       flash("Error: Subject should be 'type:id' or 'type_id'"); return;
     }
+    setImpact(null);
     try {
-      await queryStatsApi.writeTriple({ subject_id: subject, predicate, object_value: value });
+      const res = await queryStatsApi.writeTriple({ subject_id: subject, predicate, object_value: value });
       flash(`Written at ${new Date().toLocaleTimeString()}`);
       onWritten?.();
+      if (res.data.mz_timestamp_lower_bound != null) {
+        watchImpact(res.data.mz_timestamp_lower_bound);
+      }
     } catch {
       flash("Write failed");
     }
@@ -133,6 +158,25 @@ export const WriteTripleForm = ({ initialSubject = "", onWritten }: WriteTripleF
           </span>
         )}
       </div>
+      {(watchingImpact || impact) && (
+        <div className="mt-2 text-xs text-gray-600 flex items-center gap-1.5">
+          {watchingImpact && !impact && (
+            <span className="text-gray-400 animate-pulse">Watching pipeline...</span>
+          )}
+          {impact && (
+            <>
+              <span className="font-mono text-purple-700 font-semibold">{impact.impacted}</span>
+              <span className="text-gray-400">/</span>
+              <span className="font-mono text-gray-600">{impact.total}</span>
+              <span className="text-gray-500">docs re-indexed</span>
+              <span className={`font-semibold ml-1 ${impact.pct > 10 ? 'text-orange-600' : 'text-purple-600'}`}>
+                ({impact.pct}%)
+              </span>
+              {watchingImpact && <span className="text-gray-400 animate-pulse ml-1">…</span>}
+            </>
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/web/src/pages/QueryStatisticsPage.tsx
+++ b/web/src/pages/QueryStatisticsPage.tsx
@@ -893,7 +893,7 @@ export default function QueryStatisticsPage() {
       <div className="mb-6 sticky top-0 z-10 bg-gray-50 -mx-6 px-6 py-4 -mt-6">
         {/* Top row: Title and Controls */}
         <div className="flex justify-between items-start">
-          <h1 className="text-2xl font-bold text-gray-900">Agent Reference Architecture</h1>
+          <h1 className="text-2xl font-bold text-gray-900">Freshmart Demo</h1>
 
           {/* Controls group */}
           <div className="flex items-center gap-3 bg-white rounded-lg border border-gray-200 px-3 py-2 shadow-sm">
@@ -1096,7 +1096,7 @@ export default function QueryStatisticsPage() {
               <ChevronRight className="h-5 w-5 text-gray-500" />
             )}
             <div className="text-left">
-              <h3 className="text-lg font-semibold text-gray-900">Time to trusted action</h3>
+              <h3 className="text-lg font-semibold text-gray-900">System Performance</h3>
               <p className="text-xs text-gray-500">
                 Compare how quickly agents can act on fresh, trusted data across storage strategies
               </p>

--- a/web/src/pages/QueryStatisticsPage.tsx
+++ b/web/src/pages/QueryStatisticsPage.tsx
@@ -493,6 +493,8 @@ export default function QueryStatisticsPage() {
   const [useLogScale, setUseLogScale] = useState(false);
   const [useLogScaleResponseTime, setUseLogScaleResponseTime] = useState(false);
   const [lineageGraphOpen, setLineageGraphOpen] = useState(true);
+  const [contextReactiveOpen, setContextReactiveOpen] = useState(false);
+  const [freshmartUIOpen, setFreshmartUIOpen] = useState(false);
   const [trustedActionOpen, setTrustedActionOpen] = useState(true);
   const [responseChartOpen, setResponseChartOpen] = useState(true);
   const [reactionChartOpen, setReactionChartOpen] = useState(false);
@@ -1013,9 +1015,24 @@ export default function QueryStatisticsPage() {
               />
             </div>
 
-            {/* Row 2: JSON API Response — two columns */}
-            <div>
-              <h4 className="text-sm font-semibold text-gray-700 mb-2">Context obtained reactively</h4>
+            {/* Row 2: JSON API Response — two columns, collapsible */}
+            <div className="bg-gray-50 rounded-lg">
+              <div
+                role="button"
+                tabIndex={0}
+                onClick={() => setContextReactiveOpen(!contextReactiveOpen)}
+                onKeyDown={(e) => e.key === 'Enter' && setContextReactiveOpen(!contextReactiveOpen)}
+                className="px-4 py-3 flex items-center gap-2 hover:bg-gray-100 transition-colors rounded-lg cursor-pointer"
+              >
+                {contextReactiveOpen ? (
+                  <ChevronDown className="h-4 w-4 text-gray-500" />
+                ) : (
+                  <ChevronRight className="h-4 w-4 text-gray-500" />
+                )}
+                <h4 className="text-sm font-semibold text-gray-700">Context obtained reactively</h4>
+              </div>
+              {contextReactiveOpen && (
+              <div className="px-4 pb-4">
               <div className="flex gap-4 h-[300px]">
                 {/* Left: label + SQL */}
                 <div className="flex-1 bg-gray-900 rounded-lg overflow-hidden flex flex-col">
@@ -1058,6 +1075,8 @@ export default function QueryStatisticsPage() {
                   </div>
                 </div>
               </div>
+              </div>
+              )}
             </div>
 
           </div>
@@ -1315,52 +1334,6 @@ export default function QueryStatisticsPage() {
               </div>
             </div>
 
-            {/* Order Cards - conditional rendering based on view mode */}
-            <div className="grid grid-cols-3 gap-4 mb-6">
-              {/* PostgreSQL VIEW - shown in all modes */}
-              <OrderCard
-                title="PostgreSQL VIEW"
-                subtitle="Fresh but SLOW (computes every query)"
-                icon={<Database className="h-5 w-5" />}
-                iconColor="text-orange-500"
-                bgColor="border-orange-500"
-                order={orderData?.postgresql_view || null}
-                isLoading={isPolling}
-              />
-              {/* Batch MATERIALIZED VIEW - shown in batch and materialize modes */}
-              {(viewMode === 'batch' || viewMode === 'materialize') && (
-                <OrderCard
-                  title="Batch MATERIALIZED VIEW"
-                  subtitle="Fast but STALE (refreshes every 60s)"
-                  icon={<Clock className="h-5 w-5" />}
-                  iconColor="text-green-500"
-                  bgColor="border-green-500"
-                  order={orderData?.batch_cache || null}
-                  isLoading={isPolling}
-                />
-              )}
-              {/* Materialize - shown only in materialize mode */}
-              {viewMode === 'materialize' && (
-                <OrderCard
-                  title="Materialize"
-                  subtitle="Real-time sync - updates instantly"
-                  icon={<Zap className="h-5 w-5" />}
-                  iconColor="text-blue-500"
-                  bgColor="border-blue-500"
-                  order={zeroMaterializeOrder}
-                  isLoading={false}
-                />
-              )}
-            </div>
-
-            {/* Write Triple Form */}
-            <div className="mb-6">
-              <WriteTripleForm
-                initialSubject={tripleSubject}
-                onWritten={() => setTriplesRefreshTrigger(prev => prev + 1)}
-              />
-            </div>
-
             {/* Statistics Table */}
             <div className="bg-gray-50 rounded-lg mb-6">
               <button
@@ -1616,6 +1589,64 @@ export default function QueryStatisticsPage() {
                 </div>
               </div>
             )}
+
+      {/* Freshmart UI Components (Collapsible) */}
+      <div className="bg-white rounded-lg shadow mb-6">
+        <button
+          onClick={() => setFreshmartUIOpen(!freshmartUIOpen)}
+          className="w-full p-4 flex items-center justify-between hover:bg-gray-50 transition-colors"
+        >
+          <div className="flex items-center gap-2">
+            {freshmartUIOpen ? (
+              <ChevronDown className="h-5 w-5 text-gray-500" />
+            ) : (
+              <ChevronRight className="h-5 w-5 text-gray-500" />
+            )}
+            <h3 className="text-lg font-semibold text-gray-900">UI components</h3>
+          </div>
+        </button>
+        {freshmartUIOpen && (
+          <div className="p-6 pt-0">
+            <div className="grid grid-cols-3 gap-4 mb-6">
+              <OrderCard
+                title="PostgreSQL VIEW"
+                subtitle="Fresh but SLOW (computes every query)"
+                icon={<Database className="h-5 w-5" />}
+                iconColor="text-orange-500"
+                bgColor="border-orange-500"
+                order={orderData?.postgresql_view || null}
+                isLoading={isPolling}
+              />
+              {(viewMode === 'batch' || viewMode === 'materialize') && (
+                <OrderCard
+                  title="Batch MATERIALIZED VIEW"
+                  subtitle="Fast but STALE (refreshes every 60s)"
+                  icon={<Clock className="h-5 w-5" />}
+                  iconColor="text-green-500"
+                  bgColor="border-green-500"
+                  order={orderData?.batch_cache || null}
+                  isLoading={isPolling}
+                />
+              )}
+              {viewMode === 'materialize' && (
+                <OrderCard
+                  title="Materialize"
+                  subtitle="Real-time sync - updates instantly"
+                  icon={<Zap className="h-5 w-5" />}
+                  iconColor="text-blue-500"
+                  bgColor="border-blue-500"
+                  order={zeroMaterializeOrder}
+                  isLoading={false}
+                />
+              )}
+            </div>
+            <WriteTripleForm
+              initialSubject={tripleSubject}
+              onWritten={() => setTriplesRefreshTrigger(prev => prev + 1)}
+            />
+          </div>
+        )}
+      </div>
 
       {/* Vector Pipeline Card */}
       <VectorPipelineCard />

--- a/web/src/pages/QueryStatisticsPage.tsx
+++ b/web/src/pages/QueryStatisticsPage.tsx
@@ -43,7 +43,7 @@ import {
 import { LineageGraph } from "../components/LineageGraph";
 import { WhatAreTriplesCard } from "../components/WhatAreTriplesCard";
 import { WhatIsKnowledgeGraphCard } from "../components/WhatIsKnowledgeGraphCard";
-import { AgentNativeReadsCard } from "../components/AgentNativeReadsCard";
+import { VectorPipelineCard } from "../components/VectorPipelineCard";
 import { usePropagation } from "../contexts/PropagationContext";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { vscDarkPlus } from "react-syntax-highlighter/dist/esm/styles/prism";
@@ -1698,8 +1698,8 @@ export default function QueryStatisticsPage() {
               </div>
             )}
 
-      {/* Agent-native Reads Card */}
-      <AgentNativeReadsCard />
+      {/* Vector Pipeline Card */}
+      <VectorPipelineCard />
 
       {/* What is a Knowledge Graph? Card */}
       <WhatIsKnowledgeGraphCard />

--- a/web/src/pages/QueryStatisticsPage.tsx
+++ b/web/src/pages/QueryStatisticsPage.tsx
@@ -994,35 +994,52 @@ export default function QueryStatisticsPage() {
           </div>
         </button>
         {lineageGraphOpen && (
-          <div className="p-6 pt-0">
-            {/* Lineage Graph and API Response - 2 column layout */}
-            <div className="flex gap-6 mb-6">
-              {/* Left: Lineage Graph */}
-              <div className="flex-[3]">
-                <h4 className="text-sm font-semibold text-gray-700 mb-2">Context maintained proactively via live medallion architecture</h4>
-                <LineageGraph
-                  selectedNodeId={selectedNodeId}
-                  onNodeClick={handleNodeClick}
-                />
-              </div>
+          <div className="p-6 pt-0 space-y-6">
+            {/* Row 1: Lineage Graph — full width */}
+            <div>
+              <h4 className="text-sm font-semibold text-gray-700 mb-2">Context maintained proactively via live medallion architecture</h4>
+              <LineageGraph
+                selectedNodeId={selectedNodeId}
+                onNodeClick={handleNodeClick}
+              />
+            </div>
 
-              {/* Right: JSON API Response */}
-              <div className="flex-[2] flex flex-col">
-                <h4 className="text-sm font-semibold text-gray-700 mb-2">Context obtained reactively</h4>
-                <div className="bg-gray-900 rounded-lg overflow-hidden flex flex-col h-[430px]">
-                  {/* Header */}
+            {/* Row 2: JSON API Response — two columns */}
+            <div>
+              <h4 className="text-sm font-semibold text-gray-700 mb-2">Context obtained reactively</h4>
+              <div className="flex gap-4 h-[300px]">
+                {/* Left: label + SQL */}
+                <div className="flex-1 bg-gray-900 rounded-lg overflow-hidden flex flex-col">
                   <div className="px-4 py-3 bg-gray-800 border-b border-gray-700 flex-shrink-0">
                     <div className="flex items-center gap-2">
                       <Database className="h-4 w-4 text-blue-400" />
                       <span className="text-sm font-medium text-gray-200">API Response</span>
                     </div>
-                    <div className="mt-2 font-mono text-xs text-gray-400 space-y-0.5">
-                      <div><span className="text-purple-400">SELECT</span> * <span className="text-purple-400">FROM</span> orders_with_lines_mv o</div>
-                      <div><span className="text-purple-400">LEFT JOIN</span> inventory_items_with_dynamic_pricing_mv p</div>
-                      <div className="text-gray-500 pl-4"><span className="text-purple-400">ON</span> p.product_id = o.product_id <span className="text-purple-400">AND</span> p.store_id = o.store_id</div>
-                    </div>
                   </div>
-                  {/* JSON Content */}
+                  <div className="flex-1 overflow-auto px-4 py-3 font-mono text-xs text-gray-400 leading-relaxed">
+                    <div><span className="text-purple-400">SELECT</span></div>
+                    <div className="pl-4">o.order_id, o.order_number, o.order_status,</div>
+                    <div className="pl-4">o.store_id, o.customer_id,</div>
+                    <div className="pl-4">o.delivery_window_start, o.delivery_window_end,</div>
+                    <div className="pl-4">o.order_total_amount,</div>
+                    <div className="pl-4">o.customer_name, o.customer_email, o.customer_address,</div>
+                    <div className="pl-4">o.store_name, o.store_zone, o.store_address,</div>
+                    <div className="pl-4">o.assigned_courier_id, o.delivery_task_status,</div>
+                    <div className="pl-4">o.delivery_eta, o.effective_updated_at,</div>
+                    <div className="pl-4">p.base_price, p.live_price, p.price_change,</div>
+                    <div className="pl-4">p.zone_adjustment, p.perishable_adjustment,</div>
+                    <div className="pl-4">p.local_stock_adjustment, p.popularity_adjustment,</div>
+                    <div className="pl-4">p.scarcity_adjustment, p.demand_multiplier,</div>
+                    <div className="pl-4">p.demand_premium, p.stock_level</div>
+                    <div className="mt-1"><span className="text-purple-400">FROM</span> orders_with_lines_mv o</div>
+                    <div><span className="text-purple-400">LEFT JOIN</span> inventory_items_with_dynamic_pricing_mv p</div>
+                    <div className="pl-4"><span className="text-purple-400">ON</span> p.product_id = o.product_id</div>
+                    <div className="pl-4"><span className="text-purple-400">AND</span> p.store_id = o.store_id</div>
+                    <div className="mt-1"><span className="text-purple-400">WHERE</span> o.order_id = <span className="text-green-400">:order_id</span></div>
+                  </div>
+                </div>
+                {/* Right: JSON response */}
+                <div className="flex-[2] bg-gray-900 rounded-lg overflow-hidden flex flex-col">
                   <div className="flex-1 overflow-auto p-4">
                     {zeroMaterializeOrder ? (
                       <HighlightedJson data={zeroMaterializeOrder} trackingKey={selectedOrderId} />

--- a/web/src/pages/QueryStatisticsPage.tsx
+++ b/web/src/pages/QueryStatisticsPage.tsx
@@ -494,6 +494,8 @@ export default function QueryStatisticsPage() {
   const [useLogScaleResponseTime, setUseLogScaleResponseTime] = useState(false);
   const [lineageGraphOpen, setLineageGraphOpen] = useState(true);
   const [trustedActionOpen, setTrustedActionOpen] = useState(true);
+  const [responseChartOpen, setResponseChartOpen] = useState(true);
+  const [reactionChartOpen, setReactionChartOpen] = useState(false);
   const [queryStatsOpen, setQueryStatsOpen] = useState(false);
   const [lastUpdateTime, setLastUpdateTime] = useState<number>(Date.now());
   const [error, setError] = useState<string | null>(null);
@@ -997,7 +999,13 @@ export default function QueryStatisticsPage() {
           <div className="p-6 pt-0 space-y-6">
             {/* Row 1: Lineage Graph — full width */}
             <div>
-              <h4 className="text-sm font-semibold text-gray-700 mb-2">Context maintained proactively via live medallion architecture</h4>
+              <h4 className="text-sm font-semibold text-gray-700 mb-2">
+                {viewMode === 'materialize'
+                  ? 'Context maintained proactively via live medallion architecture'
+                  : viewMode === 'batch'
+                  ? 'Context is processed in periodic batches'
+                  : 'Context is calculated reactively'}
+              </h4>
               <LineageGraph
                 selectedNodeId={selectedNodeId}
                 onNodeClick={handleNodeClick}
@@ -1078,79 +1086,48 @@ export default function QueryStatisticsPage() {
         </button>
         {trustedActionOpen && (
           <div className="p-6 pt-0">
-            {/* Order Cards - conditional rendering based on view mode */}
-            <div className="grid grid-cols-3 gap-4 mb-6">
-              {/* PostgreSQL VIEW - shown in all modes */}
-              <OrderCard
-                title="PostgreSQL VIEW"
-                subtitle="Fresh but SLOW (computes every query)"
-                icon={<Database className="h-5 w-5" />}
-                iconColor="text-orange-500"
-                bgColor="border-orange-500"
-                order={orderData?.postgresql_view || null}
-                isLoading={isPolling}
-              />
-              {/* Batch MATERIALIZED VIEW - shown in batch and materialize modes */}
-              {(viewMode === 'batch' || viewMode === 'materialize') && (
-                <OrderCard
-                  title="Batch MATERIALIZED VIEW"
-                  subtitle="Fast but STALE (refreshes every 60s)"
-                  icon={<Clock className="h-5 w-5" />}
-                  iconColor="text-green-500"
-                  bgColor="border-green-500"
-                  order={orderData?.batch_cache || null}
-                  isLoading={isPolling}
-                />
-              )}
-              {/* Materialize - shown only in materialize mode */}
-              {viewMode === 'materialize' && (
-                <OrderCard
-                  title="Materialize"
-                  subtitle="Real-time sync - updates instantly"
-                  icon={<Zap className="h-5 w-5" />}
-                  iconColor="text-blue-500"
-                  bgColor="border-blue-500"
-                  order={zeroMaterializeOrder}
-                  isLoading={false}
-                />
-              )}
-            </div>
-
-            {/* Write Triple Form */}
-            <div className="mb-6">
-              <WriteTripleForm
-                initialSubject={tripleSubject}
-                onWritten={() => setTriplesRefreshTrigger(prev => prev + 1)}
-              />
-            </div>
-
-            {/* Response Time and Reaction Time Charts - Stacked */}
+            {/* Response Time and Reaction Time Charts - Stacked, each collapsible */}
             <div className="space-y-4 mb-6">
               {/* Response Time Chart */}
-              <div className="bg-gray-50 rounded-lg p-4">
-                <div className="flex items-center justify-between mb-3">
-                  <div>
-                    <h4 className="font-semibold text-gray-900">Response Time Over Time (p99/sec)</h4>
-                    <p className="text-xs text-gray-500">
-                      Query latency: how long does each query take to execute?
-                    </p>
+              <div className="bg-gray-50 rounded-lg">
+                <div
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => setResponseChartOpen(!responseChartOpen)}
+                  onKeyDown={(e) => e.key === 'Enter' && setResponseChartOpen(!responseChartOpen)}
+                  className="w-full px-4 py-3 flex items-center justify-between hover:bg-gray-100 transition-colors rounded-lg cursor-pointer"
+                >
+                  <div className="flex items-center gap-2">
+                    {responseChartOpen ? (
+                      <ChevronDown className="h-4 w-4 text-gray-500" />
+                    ) : (
+                      <ChevronRight className="h-4 w-4 text-gray-500" />
+                    )}
+                    <div className="text-left">
+                      <h4 className="font-semibold text-gray-900">Response Time Over Time (p99/sec)</h4>
+                      <p className="text-xs text-gray-500">Query latency: how long does each query take to execute?</p>
+                    </div>
                   </div>
-                  <div className="flex gap-2">
-                    <button
-                      onClick={() => setUseLogScaleResponseTime(false)}
-                      className={`px-2 py-1 text-xs rounded ${!useLogScaleResponseTime ? "bg-blue-600 text-white" : "bg-gray-200 text-gray-700"}`}
-                    >
-                      Linear
-                    </button>
-                    <button
-                      onClick={() => setUseLogScaleResponseTime(true)}
-                      className={`px-2 py-1 text-xs rounded ${useLogScaleResponseTime ? "bg-blue-600 text-white" : "bg-gray-200 text-gray-700"}`}
-                    >
-                      Log
-                    </button>
-                  </div>
+                  {responseChartOpen && (
+                    <div className="flex gap-2" onClick={(e) => e.stopPropagation()}>
+                      <button
+                        onClick={() => setUseLogScaleResponseTime(false)}
+                        className={`px-2 py-1 text-xs rounded ${!useLogScaleResponseTime ? "bg-blue-600 text-white" : "bg-gray-200 text-gray-700"}`}
+                      >
+                        Linear
+                      </button>
+                      <button
+                        onClick={() => setUseLogScaleResponseTime(true)}
+                        className={`px-2 py-1 text-xs rounded ${useLogScaleResponseTime ? "bg-blue-600 text-white" : "bg-gray-200 text-gray-700"}`}
+                      >
+                        Log
+                      </button>
+                    </div>
+                  )}
                 </div>
-                <ResponsiveContainer width="100%" height={250}>
+                {responseChartOpen && (
+                <div className="px-4 pb-4">
+                  <ResponsiveContainer width="100%" height={250}>
                   <LineChart data={responseTimeChartData}>
                     <CartesianGrid strokeDasharray="3 3" />
                     <XAxis
@@ -1219,34 +1196,51 @@ export default function QueryStatisticsPage() {
                       />
                     )}
                   </LineChart>
-                </ResponsiveContainer>
+                  </ResponsiveContainer>
+                </div>
+                )}
               </div>
 
               {/* Reaction Time Chart */}
-              <div className="bg-gray-50 rounded-lg p-4">
-                <div className="flex items-center justify-between mb-3">
-                  <div>
-                    <h4 className="font-semibold text-gray-900">Reaction Time Over Time (p99/sec)</h4>
-                    <p className="text-xs text-gray-500">
-                      Data freshness: how stale is the data when the query completes?
-                    </p>
+              <div className="bg-gray-50 rounded-lg">
+                <div
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => setReactionChartOpen(!reactionChartOpen)}
+                  onKeyDown={(e) => e.key === 'Enter' && setReactionChartOpen(!reactionChartOpen)}
+                  className="w-full px-4 py-3 flex items-center justify-between hover:bg-gray-100 transition-colors rounded-lg cursor-pointer"
+                >
+                  <div className="flex items-center gap-2">
+                    {reactionChartOpen ? (
+                      <ChevronDown className="h-4 w-4 text-gray-500" />
+                    ) : (
+                      <ChevronRight className="h-4 w-4 text-gray-500" />
+                    )}
+                    <div className="text-left">
+                      <h4 className="font-semibold text-gray-900">Reaction Time Over Time (p99/sec)</h4>
+                      <p className="text-xs text-gray-500">Data freshness: how stale is the data when the query completes?</p>
+                    </div>
                   </div>
-                  <div className="flex gap-2">
-                    <button
-                      onClick={() => setUseLogScale(false)}
-                      className={`px-2 py-1 text-xs rounded ${!useLogScale ? "bg-blue-600 text-white" : "bg-gray-200 text-gray-700"}`}
-                    >
-                      Linear
-                    </button>
-                    <button
-                      onClick={() => setUseLogScale(true)}
-                      className={`px-2 py-1 text-xs rounded ${useLogScale ? "bg-blue-600 text-white" : "bg-gray-200 text-gray-700"}`}
-                    >
-                      Log
-                    </button>
-                  </div>
+                  {reactionChartOpen && (
+                    <div className="flex gap-2" onClick={(e) => e.stopPropagation()}>
+                      <button
+                        onClick={() => setUseLogScale(false)}
+                        className={`px-2 py-1 text-xs rounded ${!useLogScale ? "bg-blue-600 text-white" : "bg-gray-200 text-gray-700"}`}
+                      >
+                        Linear
+                      </button>
+                      <button
+                        onClick={() => setUseLogScale(true)}
+                        className={`px-2 py-1 text-xs rounded ${useLogScale ? "bg-blue-600 text-white" : "bg-gray-200 text-gray-700"}`}
+                      >
+                        Log
+                      </button>
+                    </div>
+                  )}
                 </div>
-                <ResponsiveContainer width="100%" height={250}>
+                {reactionChartOpen && (
+                <div className="px-4 pb-4">
+                  <ResponsiveContainer width="100%" height={250}>
                   <LineChart data={chartData}>
                     <CartesianGrid strokeDasharray="3 3" />
                     <XAxis
@@ -1315,8 +1309,56 @@ export default function QueryStatisticsPage() {
                       />
                     )}
                   </LineChart>
-                </ResponsiveContainer>
+                  </ResponsiveContainer>
+                </div>
+                )}
               </div>
+            </div>
+
+            {/* Order Cards - conditional rendering based on view mode */}
+            <div className="grid grid-cols-3 gap-4 mb-6">
+              {/* PostgreSQL VIEW - shown in all modes */}
+              <OrderCard
+                title="PostgreSQL VIEW"
+                subtitle="Fresh but SLOW (computes every query)"
+                icon={<Database className="h-5 w-5" />}
+                iconColor="text-orange-500"
+                bgColor="border-orange-500"
+                order={orderData?.postgresql_view || null}
+                isLoading={isPolling}
+              />
+              {/* Batch MATERIALIZED VIEW - shown in batch and materialize modes */}
+              {(viewMode === 'batch' || viewMode === 'materialize') && (
+                <OrderCard
+                  title="Batch MATERIALIZED VIEW"
+                  subtitle="Fast but STALE (refreshes every 60s)"
+                  icon={<Clock className="h-5 w-5" />}
+                  iconColor="text-green-500"
+                  bgColor="border-green-500"
+                  order={orderData?.batch_cache || null}
+                  isLoading={isPolling}
+                />
+              )}
+              {/* Materialize - shown only in materialize mode */}
+              {viewMode === 'materialize' && (
+                <OrderCard
+                  title="Materialize"
+                  subtitle="Real-time sync - updates instantly"
+                  icon={<Zap className="h-5 w-5" />}
+                  iconColor="text-blue-500"
+                  bgColor="border-blue-500"
+                  order={zeroMaterializeOrder}
+                  isLoading={false}
+                />
+              )}
+            </div>
+
+            {/* Write Triple Form */}
+            <div className="mb-6">
+              <WriteTripleForm
+                initialSubject={tripleSubject}
+                onWritten={() => setTriplesRefreshTrigger(prev => prev + 1)}
+              />
             </div>
 
             {/* Statistics Table */}

--- a/web/src/pages/QueryStatisticsPage.tsx
+++ b/web/src/pages/QueryStatisticsPage.tsx
@@ -18,7 +18,6 @@ import {
   Database,
   Zap,
   Clock,
-  Edit3,
   ShoppingCart,
   User,
   Store,
@@ -44,6 +43,7 @@ import { LineageGraph } from "../components/LineageGraph";
 import { WhatAreTriplesCard } from "../components/WhatAreTriplesCard";
 import { WhatIsKnowledgeGraphCard } from "../components/WhatIsKnowledgeGraphCard";
 import { VectorPipelineCard } from "../components/VectorPipelineCard";
+import { WriteTripleForm } from "../components/WriteTripleForm";
 import { usePropagation } from "../contexts/PropagationContext";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { vscDarkPlus } from "react-syntax-highlighter/dist/esm/styles/prism";
@@ -69,43 +69,6 @@ const predicatesBySubjectType: Record<string, string[]> = {
   task: ['task_status', 'assigned_to', 'eta'],
 };
 
-// Example placeholder values for each predicate
-const placeholdersByPredicate: Record<string, string> = {
-  // Order predicates
-  order_status: 'DELIVERED',
-  order_number: 'FM-1234',
-  delivery_window_start: '2025-01-15T10:00:00',
-  delivery_window_end: '2025-01-15T12:00:00',
-  // Order line predicates (perishable_flag is derived from product, not stored)
-  quantity: '5',
-  order_line_unit_price: '12.99',
-  line_sequence: '1',
-  // Customer predicates
-  customer_name: 'John Doe',
-  customer_email: 'john@example.com',
-  customer_address: '123 Main St',
-  // Store predicates
-  store_name: 'Downtown Market',
-  store_zone: 'MAN',
-  store_address: '456 Broadway',
-  // Product predicates
-  product_name: 'Organic Apples',
-  category: 'Produce',
-  unit_price: '4.99',
-  perishable: 'true',
-  unit_weight_grams: '500',
-  // Inventory predicates
-  stock_level: '100',
-  replenishment_eta: '2025-01-16T08:00:00',
-  // Courier predicates
-  courier_name: 'Alex Smith',
-  courier_phone: '555-0123',
-  courier_status: 'AVAILABLE',
-  // Task predicates
-  task_status: 'ASSIGNED',
-  assigned_to: 'courier:C-001',
-  eta: '2025-01-15T11:30:00',
-};
 
 // Highlighted JSON component that glows when values change
 const HighlightedJson = ({ data, trackingKey }: { data: object; trackingKey?: string }) => {
@@ -626,8 +589,6 @@ export default function QueryStatisticsPage() {
   // Triple writer state
   const [tripleSubject, setTripleSubject] = useState("");
   const [triplePredicate, setTriplePredicate] = useState("quantity");
-  const [tripleValue, setTripleValue] = useState("");
-  const [writeStatus, setWriteStatus] = useState<string | null>(null);
   const userSetSubjectRef = useRef(false);
   const [triplesRefreshTrigger, setTriplesRefreshTrigger] = useState(0);
 
@@ -884,59 +845,13 @@ export default function QueryStatisticsPage() {
   }, [clearWrites]);
 
   // Handle triple row click - pre-populate the form
-  const handleTripleClick = useCallback((subject: string, predicate: string, value: string) => {
+  const handleTripleClick = useCallback((subject: string, predicate: string, _value: string) => {
     userSetSubjectRef.current = true;
     setTripleSubject(subject);
     setTriplePredicate(predicate);
-    setTripleValue(value);
   }, []);
 
   // Handle triple write
-  const handleWriteTriple = async () => {
-    if (!tripleSubject || !triplePredicate || !tripleValue) return;
-
-    // Validate input lengths
-    if (tripleSubject.length > 255) {
-      setWriteStatus("Error: Subject too long (max 255 chars)");
-      setTimeout(() => setWriteStatus(null), 3000);
-      return;
-    }
-
-    if (triplePredicate.length > 255) {
-      setWriteStatus("Error: Predicate too long (max 255 chars)");
-      setTimeout(() => setWriteStatus(null), 3000);
-      return;
-    }
-
-    if (tripleValue.length > 1000) {
-      setWriteStatus("Error: Value too long (max 1000 chars)");
-      setTimeout(() => setWriteStatus(null), 3000);
-      return;
-    }
-
-    // Validate subject format (should contain a colon or underscore)
-    if (!tripleSubject.includes(':') && !tripleSubject.includes('_')) {
-      setWriteStatus("Error: Subject should be in format 'type:id' or 'type_id'");
-      setTimeout(() => setWriteStatus(null), 3000);
-      return;
-    }
-
-    try {
-      await queryStatsApi.writeTriple({
-        subject_id: tripleSubject,
-        predicate: triplePredicate,
-        object_value: tripleValue,
-      });
-      setWriteStatus(`Written at ${new Date().toLocaleTimeString()}`);
-      setTimeout(() => setWriteStatus(null), 3000);
-      // Trigger refresh of the triples card
-      setTriplesRefreshTrigger((prev) => prev + 1);
-    } catch (err) {
-      console.error("Failed to write triple:", err);
-      setWriteStatus("Write failed");
-    }
-  };
-
   // Handle lineage graph node click
   const handleNodeClick = useCallback(async (nodeId: string) => {
     // Toggle selection if clicking the same node
@@ -1184,67 +1099,11 @@ export default function QueryStatisticsPage() {
             </div>
 
             {/* Write Triple Form */}
-            <div className="bg-gray-50 rounded-lg p-4 mb-6">
-              <div className="flex items-center gap-2 mb-3">
-                <Edit3 className="h-4 w-4 text-purple-600" />
-                <span className="font-medium text-gray-900">Write a Triple</span>
-                <span className="text-xs text-gray-500">
-                  - Update an order property and observe propagation
-                </span>
-              </div>
-
-              <div className="flex items-end gap-3">
-                <div className="flex-1">
-                  <label className="block text-xs font-medium text-gray-600 mb-1">Subject</label>
-                  <input
-                    type="text"
-                    value={tripleSubject}
-                    onChange={(e) => {
-                      userSetSubjectRef.current = true;
-                      setTripleSubject(e.target.value);
-                    }}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm text-sm focus:outline-none focus:ring-purple-500 focus:border-purple-500 bg-white"
-                    placeholder="order:FM-1001"
-                  />
-                </div>
-                <div className="flex-1">
-                  <label className="block text-xs font-medium text-gray-600 mb-1">Predicate</label>
-                  <select
-                    value={triplePredicate}
-                    onChange={(e) => setTriplePredicate(e.target.value)}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm text-sm focus:outline-none focus:ring-purple-500 focus:border-purple-500 bg-white"
-                  >
-                    {availablePredicates.map((p) => (
-                      <option key={p} value={p}>
-                        {p}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-                <div className="flex-1">
-                  <label className="block text-xs font-medium text-gray-600 mb-1">Value</label>
-                  <input
-                    type="text"
-                    value={tripleValue}
-                    onChange={(e) => setTripleValue(e.target.value)}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm text-sm focus:outline-none focus:ring-purple-500 focus:border-purple-500 bg-white"
-                    placeholder={placeholdersByPredicate[triplePredicate] || 'value'}
-                  />
-                </div>
-                <button
-                  onClick={handleWriteTriple}
-                  disabled={!tripleSubject || !triplePredicate || !tripleValue}
-                  className="px-4 py-2 bg-purple-600 text-white rounded-md hover:bg-purple-700 disabled:bg-gray-400 disabled:cursor-not-allowed text-sm"
-                >
-                  Write
-                </button>
-                {writeStatus && (
-                  <span className="text-sm text-green-600 flex items-center gap-1">
-                    <span className="inline-block w-2 h-2 rounded-full bg-green-500"></span>
-                    {writeStatus}
-                  </span>
-                )}
-              </div>
+            <div className="mb-6">
+              <WriteTripleForm
+                initialSubject={tripleSubject}
+                onWritten={() => setTriplesRefreshTrigger(prev => prev + 1)}
+              />
             </div>
 
             {/* Response Time and Reaction Time Charts - Stacked */}

--- a/web/src/pages/QueryStatisticsPage.tsx
+++ b/web/src/pages/QueryStatisticsPage.tsx
@@ -1001,7 +1001,7 @@ export default function QueryStatisticsPage() {
               <LineageGraph
                 selectedNodeId={selectedNodeId}
                 onNodeClick={handleNodeClick}
-                scenario={viewMode === 'materialize' ? 'materialize' : 'postgres'}
+                scenario={viewMode === 'materialize' ? 'materialize' : viewMode === 'batch' ? 'batch' : 'postgres'}
               />
             </div>
 

--- a/web/src/pages/QueryStatisticsPage.tsx
+++ b/web/src/pages/QueryStatisticsPage.tsx
@@ -986,7 +986,7 @@ export default function QueryStatisticsPage() {
               <ChevronRight className="h-5 w-5 text-gray-500" />
             )}
             <div className="text-left">
-              <h3 className="text-lg font-semibold text-gray-900">Live Data Products</h3>
+              <h3 className="text-lg font-semibold text-gray-900">{viewMode === 'materialize' ? 'Real-Time Data Products' : 'Data Products'}</h3>
               <p className="text-xs text-gray-500">
                 Integrate writes from siloed operational systems and apply complex business logic to transform them into live context that can be delivered at agent scale
               </p>
@@ -1001,6 +1001,7 @@ export default function QueryStatisticsPage() {
               <LineageGraph
                 selectedNodeId={selectedNodeId}
                 onNodeClick={handleNodeClick}
+                scenario={viewMode === 'materialize' ? 'materialize' : 'postgres'}
               />
             </div>
 

--- a/web/src/pages/QueryStatisticsPage.tsx
+++ b/web/src/pages/QueryStatisticsPage.tsx
@@ -990,9 +990,9 @@ export default function QueryStatisticsPage() {
               <ChevronRight className="h-5 w-5 text-gray-500" />
             )}
             <div className="text-left">
-              <h3 className="text-lg font-semibold text-gray-900">{viewMode === 'materialize' ? 'Real-Time Data Products' : 'Data Products'}</h3>
+              <h3 className="text-lg font-semibold text-gray-900">{viewMode === 'materialize' ? 'Real-time data products for agents and apps' : viewMode === 'batch' ? 'Batch data products for agents and apps' : 'Data product APIs for agents and apps'}</h3>
               <p className="text-xs text-gray-500">
-                Integrate writes from siloed operational systems and apply complex business logic to transform them into live context that can be delivered at agent scale
+                A data product is a named dataset or view that is maintained and exposed for consumption by agents or applications. Unlike a one-off query, it is designed to be discoverable, reusable, and composable across teams and services.
               </p>
             </div>
           </div>

--- a/web/src/pages/QueryStatisticsPage.tsx
+++ b/web/src/pages/QueryStatisticsPage.tsx
@@ -530,6 +530,8 @@ export default function QueryStatisticsPage() {
   const [useLogScale, setUseLogScale] = useState(false);
   const [useLogScaleResponseTime, setUseLogScaleResponseTime] = useState(false);
   const [lineageGraphOpen, setLineageGraphOpen] = useState(true);
+  const [trustedActionOpen, setTrustedActionOpen] = useState(true);
+  const [queryStatsOpen, setQueryStatsOpen] = useState(false);
   const [lastUpdateTime, setLastUpdateTime] = useState<number>(Date.now());
   const [error, setError] = useState<string | null>(null);
 
@@ -1078,6 +1080,71 @@ export default function QueryStatisticsPage() {
         </button>
         {lineageGraphOpen && (
           <div className="p-6 pt-0">
+            {/* Lineage Graph and API Response - 2 column layout */}
+            <div className="flex gap-6 mb-6">
+              {/* Left: Lineage Graph */}
+              <div className="flex-[3]">
+                <h4 className="text-sm font-semibold text-gray-700 mb-2">Context maintained proactively via live medallion architecture</h4>
+                <LineageGraph
+                  selectedNodeId={selectedNodeId}
+                  onNodeClick={handleNodeClick}
+                />
+              </div>
+
+              {/* Right: JSON API Response */}
+              <div className="flex-[2] flex flex-col">
+                <h4 className="text-sm font-semibold text-gray-700 mb-2">Context obtained reactively</h4>
+                <div className="bg-gray-900 rounded-lg overflow-hidden flex flex-col h-[430px]">
+                  {/* Header */}
+                  <div className="px-4 py-3 bg-gray-800 border-b border-gray-700 flex-shrink-0">
+                    <div className="flex items-center gap-2">
+                      <Database className="h-4 w-4 text-blue-400" />
+                      <span className="text-sm font-medium text-gray-200">API Response</span>
+                    </div>
+                    <div className="mt-2 font-mono text-xs text-gray-400 space-y-0.5">
+                      <div><span className="text-purple-400">SELECT</span> * <span className="text-purple-400">FROM</span> orders_with_lines_mv o</div>
+                      <div><span className="text-purple-400">LEFT JOIN</span> inventory_items_with_dynamic_pricing_mv p</div>
+                      <div className="text-gray-500 pl-4"><span className="text-purple-400">ON</span> p.product_id = o.product_id <span className="text-purple-400">AND</span> p.store_id = o.store_id</div>
+                    </div>
+                  </div>
+                  {/* JSON Content */}
+                  <div className="flex-1 overflow-auto p-4">
+                    {zeroMaterializeOrder ? (
+                      <HighlightedJson data={zeroMaterializeOrder} trackingKey={selectedOrderId} />
+                    ) : (
+                      <pre className="text-xs font-mono text-gray-500">Select an order to see live data...</pre>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+
+          </div>
+        )}
+      </div>
+
+      {/* Time to Trusted Action (Collapsible) */}
+      <div className="bg-white rounded-lg shadow mb-6">
+        <button
+          onClick={() => setTrustedActionOpen(!trustedActionOpen)}
+          className="w-full p-4 flex items-center justify-between hover:bg-gray-50 transition-colors"
+        >
+          <div className="flex items-center gap-2">
+            {trustedActionOpen ? (
+              <ChevronDown className="h-5 w-5 text-gray-500" />
+            ) : (
+              <ChevronRight className="h-5 w-5 text-gray-500" />
+            )}
+            <div className="text-left">
+              <h3 className="text-lg font-semibold text-gray-900">Time to trusted action</h3>
+              <p className="text-xs text-gray-500">
+                Compare how quickly agents can act on fresh, trusted data across storage strategies
+              </p>
+            </div>
+          </div>
+        </button>
+        {trustedActionOpen && (
+          <div className="p-6 pt-0">
             {/* Order Cards - conditional rendering based on view mode */}
             <div className="grid grid-cols-3 gap-4 mb-6">
               {/* PostgreSQL VIEW - shown in all modes */}
@@ -1377,16 +1444,28 @@ export default function QueryStatisticsPage() {
 
             {/* Statistics Table */}
             <div className="bg-gray-50 rounded-lg mb-6">
-              <div className="p-4 border-b border-gray-200">
-                <h3 className="font-semibold text-gray-900 flex items-center gap-2">
-                  <BarChart3 className="h-5 w-5" />
-                  Query Statistics - Orders with Lines View
-                </h3>
-                <p className="text-xs text-gray-500 mt-1">
-                  Response Time = query latency | Reaction Time = freshness (NOW - effective_updated_at) | QPS = queries/second throughput
-                </p>
-              </div>
-              <div className="overflow-x-auto">
+              <button
+                onClick={() => setQueryStatsOpen(!queryStatsOpen)}
+                className="w-full p-4 flex items-center justify-between hover:bg-gray-100 transition-colors rounded-lg"
+              >
+                <div className="flex items-center gap-2">
+                  {queryStatsOpen ? (
+                    <ChevronDown className="h-4 w-4 text-gray-500" />
+                  ) : (
+                    <ChevronRight className="h-4 w-4 text-gray-500" />
+                  )}
+                  <div className="text-left">
+                    <h3 className="font-semibold text-gray-900 flex items-center gap-2">
+                      <BarChart3 className="h-5 w-5" />
+                      Query Statistics - Orders with Lines View
+                    </h3>
+                    <p className="text-xs text-gray-500 mt-1">
+                      Response Time = query latency | Reaction Time = freshness (NOW - effective_updated_at) | QPS = queries/second throughput
+                    </p>
+                  </div>
+                </div>
+              </button>
+              {queryStatsOpen && <div className="overflow-x-auto">
                 <table className="min-w-full text-sm">
                   <thead className="bg-gray-100">
                     <tr>
@@ -1511,9 +1590,8 @@ export default function QueryStatisticsPage() {
                           <div className="flex items-center gap-2">
                             <Zap className="h-4 w-4 text-blue-500" />
                             <div>
-                              <div className="font-medium text-gray-900 flex items-center gap-1">
+                              <div className="font-medium text-gray-900">
                                 Materialize
-                                <span className="text-xs text-blue-600 font-normal bg-blue-100 px-1 rounded">Best</span>
                               </div>
                               <div className="text-xs text-gray-500">Fast AND Fresh (incremental via CDC)</div>
                             </div>
@@ -1544,51 +1622,16 @@ export default function QueryStatisticsPage() {
                     )}
                   </tbody>
                 </table>
-              </div>
+              </div>}
             </div>
 
-            {/* Lineage Graph and API Response - 2 column layout */}
-            <div className="flex gap-6">
-              {/* Left: Lineage Graph */}
-              <div className="flex-[3]">
-                <h4 className="text-sm font-semibold text-gray-700 mb-2">Context maintained proactively via live medallion architecture</h4>
-                <LineageGraph
-                  selectedNodeId={selectedNodeId}
-                  onNodeClick={handleNodeClick}
-                />
-              </div>
+          </div>
+        )}
+      </div>
 
-              {/* Right: JSON API Response */}
-              <div className="flex-[2] flex flex-col">
-                <h4 className="text-sm font-semibold text-gray-700 mb-2">Context obtained reactively</h4>
-                <div className="bg-gray-900 rounded-lg overflow-hidden flex flex-col h-[430px]">
-                  {/* Header */}
-                  <div className="px-4 py-3 bg-gray-800 border-b border-gray-700 flex-shrink-0">
-                    <div className="flex items-center gap-2">
-                      <Database className="h-4 w-4 text-blue-400" />
-                      <span className="text-sm font-medium text-gray-200">API Response</span>
-                    </div>
-                    <div className="mt-2 font-mono text-xs text-gray-400 space-y-0.5">
-                      <div><span className="text-purple-400">SELECT</span> * <span className="text-purple-400">FROM</span> orders_with_lines_mv o</div>
-                      <div><span className="text-purple-400">LEFT JOIN</span> inventory_items_with_dynamic_pricing_mv p</div>
-                      <div className="text-gray-500 pl-4"><span className="text-purple-400">ON</span> p.product_id = o.product_id <span className="text-purple-400">AND</span> p.store_id = o.store_id</div>
-                    </div>
-                  </div>
-                  {/* JSON Content */}
-                  <div className="flex-1 overflow-auto p-4">
-                    {zeroMaterializeOrder ? (
-                      <HighlightedJson data={zeroMaterializeOrder} trackingKey={selectedOrderId} />
-                    ) : (
-                      <pre className="text-xs font-mono text-gray-500">Select an order to see live data...</pre>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            {/* View Definition Modal */}
-            {selectedNodeId && (
-              <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      {/* View Definition Modal */}
+      {selectedNodeId && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
                 {/* Backdrop */}
                 <div
                   className="absolute inset-0 bg-black/50"
@@ -1654,9 +1697,6 @@ export default function QueryStatisticsPage() {
                 </div>
               </div>
             )}
-          </div>
-        )}
-      </div>
 
       {/* Agent-native Reads Card */}
       <AgentNativeReadsCard />


### PR DESCRIPTION
## Summary

- **Vector pipeline card**: full-width layout (removed "How it works" column), top-3 results with clickable `order_id` to pre-fill Write Triple subject, full-width embedding strip with flash animation on re-embed, compact result cards with line items and live pricing
- **Index impact counter**: fixed `mz_now()` → wall-clock ms bug (was always returning 0); extended to count both `orders` and `inventory` indexes with per-index breakdown
- **Propagation bar**: removed `(N updates)` count label

## Key bug fixes

- `mz_now()` in a standalone Materialize SELECT returns `2^64-1` (a sentinel), not epoch ms — switched to `int(time.time() * 1000)` on the API side and `datetime.now(utc).timestamp() * 1000` in search-sync, so both sides share the same wall-clock time domain
- `mz_timestamp` stamping moved into `BaseSubscribeWorker._flush_batch` so the inventory worker gets it automatically; previously only order docs were stamped

## Test plan

- [ ] Write a triple in the Vector Pipeline card — impact counter should show combined orders + inventory count
- [ ] Click an `order_id` badge in a result card — subject field in Write Triple should pre-fill
- [ ] Propagation bar should show "Index Propagation" heading without a `(N updates)` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)