### PR TITLE
Add QR code modal for live demo presentations

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -15,6 +15,7 @@
         "axios": "^1.6.5",
         "dagre": "^0.8.5",
         "lucide-react": "^0.309.0",
+        "qrcode.react": "^4.2.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-markdown": "^10.1.0",
@@ -128,7 +129,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -506,7 +506,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -530,7 +529,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -711,7 +709,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1666,7 +1663,6 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -1744,7 +1740,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1841,7 +1836,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
       "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -5069,7 +5063,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -5174,7 +5167,6 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -5602,7 +5594,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6065,7 +6056,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -6762,7 +6752,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7363,7 +7352,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -8621,7 +8609,6 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
       "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -9195,7 +9182,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -9243,7 +9229,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -11029,7 +11014,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -11397,6 +11381,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -11460,7 +11453,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -11473,7 +11465,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -11486,8 +11477,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -11521,7 +11511,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -11696,8 +11685,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -12746,7 +12734,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13347,7 +13334,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13635,7 +13621,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,7 @@
     "axios": "^1.6.5",
     "dagre": "^0.8.5",
     "lucide-react": "^0.309.0",
+    "qrcode.react": "^4.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^10.1.0",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,13 +12,15 @@ import VectorSearchPage from './pages/VectorSearchPage'
 import BundlingPage from './pages/BundlingPage'
 import { PropagationProvider } from './contexts/PropagationContext'
 import { ChatProvider, useChat } from './contexts/ChatContext'
-import { LayoutProvider } from './contexts/LayoutContext'
+import { LayoutProvider, useLayout } from './contexts/LayoutContext'
 import PropagationWidget from './components/PropagationWidget'
 import ChatWidget from './components/ChatWidget'
 import Sidebar from './components/Sidebar'
+import QrModal from './components/QrModal'
 
 function AppLayout() {
   const { isOpen: chatOpen, isExpanded: chatExpanded } = useChat()
+  const { showQr, setShowQr } = useLayout()
 
   return (
     <div className="flex h-screen">
@@ -53,6 +55,9 @@ function AppLayout() {
 
       {/* Propagation Widget */}
       <PropagationWidget />
+
+      {/* QR Code Modal */}
+      <QrModal open={showQr} onClose={() => setShowQr(false)} />
     </div>
   )
 }

--- a/web/src/components/QrModal.tsx
+++ b/web/src/components/QrModal.tsx
@@ -1,11 +1,7 @@
-import { useEffect } from 'react';
-import { QRCodeSVG } from 'qrcode.react';
-import { X } from 'lucide-react';
-
-const QR_URL_KEY = 'demo_qr_url';
-const QR_CTA_KEY = 'demo_qr_cta';
-const DEFAULT_URL = 'https://materialize.com/demo/';
-const DEFAULT_CTA = 'Schedule a demo';
+import { useEffect } from 'react'
+import { QRCodeSVG } from 'qrcode.react'
+import { X } from 'lucide-react'
+import { QR_URL_KEY, QR_CTA_KEY, DEFAULT_QR_URL, DEFAULT_QR_CTA } from '../qrConfig'
 
 interface QrModalProps {
   open: boolean;
@@ -13,8 +9,8 @@ interface QrModalProps {
 }
 
 export default function QrModal({ open, onClose }: QrModalProps) {
-  const url = localStorage.getItem(QR_URL_KEY) || DEFAULT_URL;
-  const cta = localStorage.getItem(QR_CTA_KEY) || DEFAULT_CTA;
+  const url = localStorage.getItem(QR_URL_KEY) || DEFAULT_QR_URL
+  const cta = localStorage.getItem(QR_CTA_KEY) || DEFAULT_QR_CTA
 
   useEffect(() => {
     if (!open) return;
@@ -31,8 +27,7 @@ export default function QrModal({ open, onClose }: QrModalProps) {
       onClick={onClose}
     >
       <div
-        className="relative bg-white rounded-3xl shadow-2xl flex flex-col items-center gap-6 p-16 mx-4"
-        style={{ minWidth: 520 }}
+        className="relative bg-white rounded-3xl shadow-2xl flex flex-col items-center gap-6 p-16 mx-4 min-w-[520px]"
         onClick={e => e.stopPropagation()}
       >
         <button

--- a/web/src/components/QrModal.tsx
+++ b/web/src/components/QrModal.tsx
@@ -1,0 +1,55 @@
+import { useEffect } from 'react';
+import { QRCodeSVG } from 'qrcode.react';
+import { X } from 'lucide-react';
+
+const QR_URL_KEY = 'demo_qr_url';
+const QR_CTA_KEY = 'demo_qr_cta';
+const DEFAULT_URL = 'https://materialize.com/demo/';
+const DEFAULT_CTA = 'Schedule a demo';
+
+interface QrModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function QrModal({ open, onClose }: QrModalProps) {
+  const url = localStorage.getItem(QR_URL_KEY) || DEFAULT_URL;
+  const cta = localStorage.getItem(QR_CTA_KEY) || DEFAULT_CTA;
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/65 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="relative bg-white rounded-3xl shadow-2xl flex flex-col items-center gap-6 p-16 mx-4"
+        style={{ minWidth: 520 }}
+        onClick={e => e.stopPropagation()}
+      >
+        <button
+          onClick={onClose}
+          className="absolute top-5 right-5 p-2 rounded-full text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+        >
+          <X className="h-5 w-5" />
+        </button>
+
+        <p className="text-3xl font-bold text-gray-900 text-center leading-tight">{cta}</p>
+
+        <div className="rounded-2xl overflow-hidden p-3 bg-white ring-1 ring-gray-100 shadow-inner">
+          <QRCodeSVG value={url} size={380} bgColor="#ffffff" fgColor="#111827" level="M" />
+        </div>
+
+        <p className="text-sm text-gray-400 font-mono break-all text-center">{url}</p>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -10,6 +10,7 @@ import {
   BarChart3,
   Layers,
   Search,
+  QrCode,
   ChevronLeft,
   ChevronRight,
 } from 'lucide-react'
@@ -29,7 +30,7 @@ const navItems = [
 ]
 
 export default function Sidebar() {
-  const { sidebarCollapsed, toggleSidebar } = useLayout()
+  const { sidebarCollapsed, toggleSidebar, setShowQr } = useLayout()
 
   return (
     <aside
@@ -80,6 +81,16 @@ export default function Sidebar() {
           </NavLink>
         ))}
       </nav>
+
+      {/* QR Code Button */}
+      <button
+        onClick={() => setShowQr(true)}
+        title={sidebarCollapsed ? 'Show QR Code' : undefined}
+        className={`flex items-center gap-3 px-4 py-3 text-sm transition-colors border-t border-gray-700 text-gray-300 hover:bg-gray-800 ${sidebarCollapsed ? 'justify-center' : ''}`}
+      >
+        <QrCode className="h-5 w-5 flex-shrink-0" />
+        {!sidebarCollapsed && <span>Show QR Code</span>}
+      </button>
     </aside>
   )
 }

--- a/web/src/contexts/LayoutContext.tsx
+++ b/web/src/contexts/LayoutContext.tsx
@@ -4,6 +4,8 @@ interface LayoutContextValue {
   sidebarCollapsed: boolean;
   toggleSidebar: () => void;
   setSidebarCollapsed: (collapsed: boolean) => void;
+  showQr: boolean;
+  setShowQr: (show: boolean) => void;
 }
 
 const LayoutContext = createContext<LayoutContextValue | null>(null);
@@ -13,6 +15,7 @@ export function LayoutProvider({ children }: { children: ReactNode }) {
     const saved = localStorage.getItem('sidebarCollapsed');
     return saved === 'true';
   });
+  const [showQr, setShowQr] = useState(false);
 
   const toggleSidebar = useCallback(() => {
     setSidebarCollapsed(prev => {
@@ -31,7 +34,9 @@ export function LayoutProvider({ children }: { children: ReactNode }) {
     <LayoutContext.Provider value={{
       sidebarCollapsed,
       toggleSidebar,
-      setSidebarCollapsed: handleSetSidebarCollapsed
+      setSidebarCollapsed: handleSetSidebarCollapsed,
+      showQr,
+      setShowQr,
     }}>
       {children}
     </LayoutContext.Provider>

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1,10 +1,19 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'react'
 import { healthApi, loadgenApi, LoadGenProfile, LoadGenProfileInfo } from '../api/client'
-import { CheckCircle, XCircle, Server, Database, Search, ExternalLink, BarChart3, FileText, Layers, Play, Square, Loader2, ShoppingCart, Truck } from 'lucide-react'
+import { CheckCircle, XCircle, Server, Database, Search, ExternalLink, BarChart3, FileText, Layers, Play, Square, Loader2, ShoppingCart, Truck, QrCode } from 'lucide-react'
+
+const QR_URL_KEY = 'demo_qr_url'
+const QR_CTA_KEY = 'demo_qr_cta'
+const DEFAULT_QR_URL = 'https://materialize.com/demo/'
+const DEFAULT_QR_CTA = 'Schedule a demo'
 
 export default function SettingsPage() {
   const queryClient = useQueryClient()
+
+  // Demo presentation state
+  const [qrUrl, setQrUrl] = useState(() => localStorage.getItem(QR_URL_KEY) || DEFAULT_QR_URL)
+  const [qrCta, setQrCta] = useState(() => localStorage.getItem(QR_CTA_KEY) || DEFAULT_QR_CTA)
 
   // Demand state
   const [demandProfile, setDemandProfile] = useState<LoadGenProfile>('demo')
@@ -648,6 +657,45 @@ export default function SettingsPage() {
           <div className="text-xs text-gray-500 pt-2 border-t">
             <strong>Note:</strong> All orders are automatically synced to OpenSearch for full-text search capabilities.
             Currently indexing orders with customer names, addresses, and order details.
+          </div>
+        </div>
+      </div>
+
+      {/* Demo Presentation */}
+      <div className="bg-white rounded-lg shadow p-6 mb-6">
+        <h2 className="font-semibold text-lg mb-1 flex items-center gap-2">
+          <QrCode className="h-5 w-5 text-gray-500" />
+          Demo Presentation
+        </h2>
+        <p className="text-sm text-gray-500 mb-4">Configure the QR code shown via the sidebar button during live demos.</p>
+        <div className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Demo URL</label>
+            <input
+              type="url"
+              value={qrUrl}
+              onChange={(e) => {
+                setQrUrl(e.target.value)
+                localStorage.setItem(QR_URL_KEY, e.target.value)
+              }}
+              placeholder={DEFAULT_QR_URL}
+              className="w-full px-3 py-2 border rounded-lg"
+            />
+            <p className="text-xs text-gray-500 mt-1">The URL encoded in the QR code.</p>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">CTA Text</label>
+            <input
+              type="text"
+              value={qrCta}
+              onChange={(e) => {
+                setQrCta(e.target.value)
+                localStorage.setItem(QR_CTA_KEY, e.target.value)
+              }}
+              placeholder={DEFAULT_QR_CTA}
+              className="w-full px-3 py-2 border rounded-lg"
+            />
+            <p className="text-xs text-gray-500 mt-1">Displayed above the QR code in the modal.</p>
           </div>
         </div>
       </div>

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -2,11 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'react'
 import { healthApi, loadgenApi, LoadGenProfile, LoadGenProfileInfo } from '../api/client'
 import { CheckCircle, XCircle, Server, Database, Search, ExternalLink, BarChart3, FileText, Layers, Play, Square, Loader2, ShoppingCart, Truck, QrCode } from 'lucide-react'
-
-const QR_URL_KEY = 'demo_qr_url'
-const QR_CTA_KEY = 'demo_qr_cta'
-const DEFAULT_QR_URL = 'https://materialize.com/demo/'
-const DEFAULT_QR_CTA = 'Schedule a demo'
+import { QR_URL_KEY, QR_CTA_KEY, DEFAULT_QR_URL, DEFAULT_QR_CTA } from '../qrConfig'
 
 export default function SettingsPage() {
   const queryClient = useQueryClient()

--- a/web/src/qrConfig.ts
+++ b/web/src/qrConfig.ts
@@ -1,0 +1,4 @@
+export const QR_URL_KEY = 'demo_qr_url'
+export const QR_CTA_KEY = 'demo_qr_cta'
+export const DEFAULT_QR_URL = 'https://materialize.com/demo/'
+export const DEFAULT_QR_CTA = 'Schedule a demo'


### PR DESCRIPTION
## Summary

- Adds a QR code button at the bottom of the sidebar nav (icon-only when collapsed, labeled when expanded)
- Clicking it opens a centered modal with a dimmed/blurred backdrop, large QR code, and CTA text above it
- URL and CTA text are configurable in a new **Demo Presentation** section in Settings, persisted to localStorage
- Defaults: URL = `https://materialize.com/demo/`, CTA = "Schedule a demo"
- Modal dismisses via click-outside, Escape key, or the X button

## Test plan

- [ ] Click "Show QR Code" in sidebar — modal appears centered with QR code and CTA
- [ ] Verify QR code encodes the default URL
- [ ] Change URL and CTA in Settings, reopen modal — changes reflected immediately
- [ ] Collapse sidebar — button shows icon only with tooltip
- [ ] Dismiss via Escape, backdrop click, and X button

🤖 Generated with [Claude Code](https://claude.com/claude-code)