### PR TITLE
Cross-encoder reranking with a kNN-vs-reranked comparison UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,14 @@ for hit in results:
 
 **Replicating this pattern:** the structural insight is transport- and model-agnostic. Materialize emits a Debezium change stream; the perfect-embeddings SMT re-embeds only changed text columns; an UPSERT sink preserves untouched vectors. Swap the local shim for the real OpenAI API by changing `transforms.embed.openai.endpoint`/`api.key`; swap OpenSearch for Elasticsearch by using the Confluent ES sink (`write.method=UPSERT`).
 
+## Cross-encoder reranking
+
+Vector kNN is a fast first stage (a bi-encoder embeds query and docs separately). The `/vector/orders/reranked` endpoint adds a second, more precise stage: a **cross-encoder** (`Xenova/ms-marco-MiniLM-L-6-v2`, served by the embeddings shim's `/rerank`) that jointly scores `(query, document)` pairs and reorders the candidate set.
+
+The point — and the Materialize angle — is that the reranker reads a **document assembled fresh from Materialize per candidate**: each order's items, category, live price, stock, and status, hydrated in a single millisecond read (surfaced as the `features from MZ` timing). The business signals (price/stock/status) are written into the model input *on purpose* — they ride along current; a cross-encoder weights query↔text relevance so it may not act strongly on them, but they're in the input, fresh. Editing a triple changes what the reranker reads, so the reranked order updates live.
+
+The Vector Pipeline card's **Rerank (cross-encoder)** toggle shows a row-per-candidate comparison: ① where kNN ranked it · ② the live-from-MZ document the model read + its cross-encoder score · ③ the reranked position and delta.
+
 ---
 
 ## Core Components
@@ -263,6 +271,7 @@ Materialize sinks the `orders` and `inventory` views into Redpanda; Kafka Connec
 | Endpoint | Description |
 |----------|-------------|
 | `GET /vector/orders` | Embed query → kNN → hydrate from Materialize. Accepts `store_zone` and `order_status` filters for hybrid search. |
+| `GET /vector/orders/reranked` | Two-stage: kNN recall (`candidates`, default 25) → cross-encoder rerank. Returns both orderings + each candidate's rerank input/score + stage timings. |
 | `GET /impact?since_mz_timestamp=T` | Count docs re-indexed across orders + inventory since timestamp T. Returns combined impacted/total/pct plus per-index breakdown. All four OpenSearch `_count` calls run concurrently. |
 | `GET /index-stats` | Total doc count from OpenSearch |
 | `GET /embedding-metrics` | Embedding SMT diff counters (computed / skipped / skip ratio) read from the Connect worker via Jolokia. Degrades to `available:false` when Connect/Jolokia is down. |

--- a/README.md
+++ b/README.md
@@ -246,11 +246,11 @@ for hit in results:
 
 ## Cross-encoder reranking
 
-Vector kNN is a fast first stage (a bi-encoder embeds query and docs separately). The `/vector/orders/reranked` endpoint adds a second, more precise stage: a **cross-encoder** (`Xenova/ms-marco-MiniLM-L-6-v2`, served by the embeddings shim's `/rerank`) that jointly scores `(query, document)` pairs and reorders the candidate set.
+Vector search is fast but approximate — it embeds the query and each order independently and matches by nearest vector. Reranking adds a second, sharper pass. The `/vector/orders/reranked` endpoint takes the top candidates from vector search and re-scores them with a **cross-encoder** (`Xenova/ms-marco-MiniLM-L-6-v2`), a model that reads the query and an order *together* and judges relevance far more precisely than separately-embedded vectors can.
 
-The point — and the Materialize angle — is that the reranker reads a **document assembled fresh from Materialize per candidate**: each order's items, category, live price, stock, and status, hydrated in a single millisecond read (surfaced as the `features from MZ` timing). The business signals (price/stock/status) are written into the model input *on purpose* — they ride along current; a cross-encoder weights query↔text relevance so it may not act strongly on them, but they're in the input, fresh. Editing a triple changes what the reranker reads, so the reranked order updates live.
+What makes this practical in production is that the cross-encoder scores each order against its **current** state — line items, category, live price, stock, and status. Materialize keeps that context continuously up to date from the change stream, so there's no nightly rebuild and no staleness: edit an order and the next search reranks against the new reality. The latency breakdown surfaces the cost of each stage — retrieval, fetching the order context from Materialize, and the rerank itself — so you can see where the time goes.
 
-The Vector Pipeline card's **Rerank (cross-encoder)** toggle shows a row-per-candidate comparison: ① where kNN ranked it · ② the live-from-MZ document the model read + its cross-encoder score · ③ the reranked position and delta.
+Toggle **Rerank (cross-encoder)** on the Vector Pipeline card to compare the two side by side, row per candidate: ① where vector search ranked it · ② the document the model scored and its cross-encoder score · ③ the reranked position and how far it moved.
 
 ---
 

--- a/api/src/config.py
+++ b/api/src/config.py
@@ -35,6 +35,10 @@ class Settings(BaseSettings):
     # JMX diff counters over HTTP, read by /api/search/embedding-metrics.
     jolokia_url: str = "http://connect:8778"
 
+    # Local embeddings shim — its /rerank endpoint runs the cross-encoder used
+    # by the reranked vector search (second-stage precision over kNN recall).
+    rerank_url: str = "http://embeddings:8080/rerank"
+
     # Application
     log_level: str = "INFO"
     api_port: int = 8080

--- a/api/src/freshmart/service.py
+++ b/api/src/freshmart/service.py
@@ -165,6 +165,60 @@ class FreshMartService:
             effective_updated_at=row.effective_updated_at,
         )
 
+    async def get_order_with_line_items(self, order_id: str) -> Optional[dict]:
+        """Order head + live line items in a single Materialize read.
+
+        Reads ``line_items`` straight from ``orders_with_lines_mv``, which joins
+        ``inventory_items_with_dynamic_pricing_mv`` — so each item's
+        ``live_price`` and ``current_stock`` reflect the *current* state in
+        Materialize, not the value last sunk to the search index. Used to
+        assemble the cross-encoder's document at query time, so editing a triple
+        (a price, a stock level) changes what the reranker reads immediately.
+        """
+        if self.use_materialize:
+            result = await self.session.execute(
+                text(
+                    """
+                    SELECT order_number, order_status, line_items
+                    FROM orders_with_lines_mv
+                    WHERE order_id = :order_id
+                    """
+                ),
+                {"order_id": order_id},
+            )
+            row = result.fetchone()
+            if not row:
+                return None
+            items = row.line_items
+            # jsonb may arrive already decoded (list) or as a JSON string.
+            if isinstance(items, str):
+                items = json.loads(items)
+            return {
+                "order_number": row.order_number,
+                "order_status": row.order_status,
+                "line_items": items if isinstance(items, list) else [],
+            }
+
+        # PostgreSQL fallback: order_lines_flat carries name/category/unit_price
+        # but no dynamic price or stock (those live only in the pricing views).
+        order = await self.get_order(order_id)
+        if order is None:
+            return None
+        lines = await self.list_order_lines(order_id)
+        return {
+            "order_number": order.order_number,
+            "order_status": order.order_status,
+            "line_items": [
+                {
+                    "product_name": ln.product_name,
+                    "category": ln.category,
+                    "unit_price": float(ln.unit_price) if ln.unit_price is not None else None,
+                    "current_stock": None,
+                }
+                for ln in lines
+            ],
+        }
+
     # =========================================================================
     # Inventory
     # =========================================================================

--- a/api/src/routes/search.py
+++ b/api/src/routes/search.py
@@ -458,13 +458,18 @@ RERANK_TIMEOUT = 30.0
 DEFAULT_RERANK_CANDIDATES = 25
 
 
-def _build_rerank_doc(live: dict, line_items: list) -> str:
-    """Assemble the document the cross-encoder reads, from fresh Materialize
-    fields: each item's name, category, live price and stock, plus order status.
+def _build_rerank_doc_parts(live: dict, line_items: list) -> dict:
+    """Assemble the document the cross-encoder reads, split by provenance so the
+    UI can show which parts came from where:
 
-    The business signals (price/stock/status) are written into the model input
-    on purpose — they ride along fresh from Materialize. A cross-encoder weights
-    query↔text relevance and may not act on them, but they are in the input.
+      - ``mz``    — the order head (number + status), read live from Materialize
+                    at query time (the ``feature_fetch_ms`` stage).
+      - ``index`` — the line items (name, category, live price, stock), served
+                    from the OpenSearch ``_source`` retrieved in the kNN stage.
+
+    ``doc`` is the exact concatenation handed to the model (``mz`` + ``index``).
+    The business signals ride along in the input on purpose; a cross-encoder
+    weights query↔text relevance and may not act on them, but they are present.
     """
     items = []
     for it in line_items:
@@ -490,7 +495,15 @@ def _build_rerank_doc(live: dict, line_items: list) -> str:
     status = live.get("order_status")
     if status:
         head += f", status {status}"
-    return f"{head}. Items: " + "; ".join(items) if items else head
+
+    index_seg = "Items: " + "; ".join(items) if items else ""
+    doc = f"{head}. {index_seg}" if index_seg else head
+    return {"doc": doc, "mz": head, "index": index_seg}
+
+
+def _build_rerank_doc(live: dict, line_items: list) -> str:
+    """The exact string handed to the cross-encoder (mz head + indexed items)."""
+    return _build_rerank_doc_parts(live, line_items)["doc"]
 
 
 @router.get("/vector/orders/reranked")
@@ -561,13 +574,16 @@ async def reranked_vector_search_orders(
             return None
         live = order.model_dump(mode="json")
         line_items = _parse_line_items(source.get("line_items"))
+        parts = _build_rerank_doc_parts(live, line_items)
         return {
             "order_id": order_id,
             "order_number": live.get("order_number") or order_id,
             "status": live.get("order_status"),
             "knn_score": round(float(hit.get("_score", 0.0)), 4),
             "original_rank": rank,  # 1-based, in kNN order
-            "doc": _build_rerank_doc(live, line_items),
+            "doc": parts["doc"],          # exact string the model scored
+            "doc_mz": parts["mz"],        # order head — live from Materialize
+            "doc_index": parts["index"],  # line items — from the search index
         }
 
     hydrated = await asyncio.gather(*[_hydrate(i + 1, h) for i, h in enumerate(hits)])

--- a/api/src/routes/search.py
+++ b/api/src/routes/search.py
@@ -458,18 +458,15 @@ RERANK_TIMEOUT = 30.0
 DEFAULT_RERANK_CANDIDATES = 25
 
 
-def _build_rerank_doc_parts(live: dict, line_items: list) -> dict:
-    """Assemble the document the cross-encoder reads, split by provenance so the
-    UI can show which parts came from where:
+def _build_rerank_doc(live: dict, line_items: list) -> str:
+    """Assemble the document the cross-encoder reads, entirely from a live
+    Materialize read: the order head (number + status) plus each item's name,
+    category, live price and current stock.
 
-      - ``mz``    — the order head (number + status), read live from Materialize
-                    at query time (the ``feature_fetch_ms`` stage).
-      - ``index`` — the line items (name, category, live price, stock), served
-                    from the OpenSearch ``_source`` retrieved in the kNN stage.
-
-    ``doc`` is the exact concatenation handed to the model (``mz`` + ``index``).
-    The business signals ride along in the input on purpose; a cross-encoder
-    weights query↔text relevance and may not act on them, but they are present.
+    The business signals (price/stock/status) are written into the model input
+    on purpose — they ride along fresh from Materialize, so editing a triple
+    changes what the reranker reads. A cross-encoder weights query↔text
+    relevance and may not act strongly on them, but they are in the input.
     """
     items = []
     for it in line_items:
@@ -495,15 +492,7 @@ def _build_rerank_doc_parts(live: dict, line_items: list) -> dict:
     status = live.get("order_status")
     if status:
         head += f", status {status}"
-
-    index_seg = "Items: " + "; ".join(items) if items else ""
-    doc = f"{head}. {index_seg}" if index_seg else head
-    return {"doc": doc, "mz": head, "index": index_seg}
-
-
-def _build_rerank_doc(live: dict, line_items: list) -> str:
-    """The exact string handed to the cross-encoder (mz head + indexed items)."""
-    return _build_rerank_doc_parts(live, line_items)["doc"]
+    return f"{head}. Items: " + "; ".join(items) if items else head
 
 
 @router.get("/vector/orders/reranked")
@@ -523,17 +512,24 @@ async def reranked_vector_search_orders(
     Returns both orderings + each candidate's rerank input/score + stage timings,
     so the UI can compare kNN vs reranked and show exactly what the model read.
     """
-    t0 = time.perf_counter()
+    # Stage 1a: embed the query. Timed separately from OpenSearch so a cold
+    # model load doesn't masquerade as slow retrieval.
+    t_embed = time.perf_counter()
     try:
         async with asyncio.timeout(EMBED_TIMEOUT):
             embedder = await asyncio.to_thread(get_query_embedder)
             vector = (await asyncio.to_thread(embedder.embed, [q]))[0]
     except asyncio.TimeoutError:
         raise HTTPException(status_code=503, detail="Embedding model unavailable — check API logs.")
+    embed_ms = round((time.perf_counter() - t_embed) * 1000, 1)
 
+    # Stage 1b: kNN recall against OpenSearch. We only need the candidate's id
+    # and the embedding_text it matched on — the document the model scores is
+    # read fresh from Materialize below, not from the index.
+    t_recall = time.perf_counter()
     search_body = {
         "query": {"knn": {"embedding_text_embedding": {"vector": list(vector), "k": candidates}}},
-        "_source": ["order_id", "embedding_text", "line_items"],
+        "_source": ["order_id", "embedding_text"],
         "size": candidates,
     }
     try:
@@ -544,20 +540,22 @@ async def reranked_vector_search_orders(
                 headers={"Content-Type": "application/json"},
             )
             if resp.status_code == 404:
-                return {"query": q, "model": None, "results": [], "timings": {}}
+                return {"query": q, "model": None, "results": [], "timings": {"embed_ms": embed_ms}}
             resp.raise_for_status()
             os_result = resp.json()
     except httpx.ConnectError:
         raise HTTPException(status_code=503, detail="OpenSearch is not available.")
     except httpx.HTTPStatusError as e:
         raise HTTPException(status_code=502, detail=f"OpenSearch error: {e.response.text}")
-    retrieval_ms = round((time.perf_counter() - t0) * 1000, 1)
+    recall_ms = round((time.perf_counter() - t_recall) * 1000, 1)
 
     hits = os_result.get("hits", {}).get("hits", []) or []
     if not hits:
-        return {"query": q, "model": None, "results": [], "timings": {"retrieval_ms": retrieval_ms}}
+        return {"query": q, "model": None, "results": [],
+                "timings": {"embed_ms": embed_ms, "recall_ms": recall_ms}}
 
-    # Stage 2a: hydrate candidates from Materialize — the fresh feature fetch.
+    # Stage 2a: hydrate each candidate's document live from Materialize — order
+    # head + items with current price/stock. This is the fresh feature fetch.
     t1 = time.perf_counter()
 
     async def _hydrate(rank: int, hit: dict) -> dict | None:
@@ -566,24 +564,22 @@ async def reranked_vector_search_orders(
         if not order_id:
             return None
         try:
-            order = await service.get_order(order_id)
+            feat = await service.get_order_with_line_items(order_id)
         except Exception as e:
             logger.warning(f"Failed to hydrate order {order_id} from Materialize: {e}", exc_info=True)
             return None
-        if order is None:
+        if feat is None:
             return None
-        live = order.model_dump(mode="json")
-        line_items = _parse_line_items(source.get("line_items"))
-        parts = _build_rerank_doc_parts(live, line_items)
         return {
             "order_id": order_id,
-            "order_number": live.get("order_number") or order_id,
-            "status": live.get("order_status"),
+            "order_number": feat.get("order_number") or order_id,
+            "status": feat.get("order_status"),
             "knn_score": round(float(hit.get("_score", 0.0)), 4),
             "original_rank": rank,  # 1-based, in kNN order
-            "doc": parts["doc"],          # exact string the model scored
-            "doc_mz": parts["mz"],        # order head — live from Materialize
-            "doc_index": parts["index"],  # line items — from the search index
+            # The document the model scores — read live from Materialize.
+            "doc": _build_rerank_doc(feat, feat.get("line_items") or []),
+            # What kNN matched on — the text embedded at index time (OpenSearch).
+            "matched_text": source.get("embedding_text") or "",
         }
 
     hydrated = await asyncio.gather(*[_hydrate(i + 1, h) for i, h in enumerate(hits)])
@@ -591,7 +587,7 @@ async def reranked_vector_search_orders(
     feature_fetch_ms = round((time.perf_counter() - t1) * 1000, 1)
     if not cand:
         return {"query": q, "model": None, "results": [],
-                "timings": {"retrieval_ms": retrieval_ms, "feature_fetch_ms": feature_fetch_ms}}
+                "timings": {"embed_ms": embed_ms, "recall_ms": recall_ms, "feature_fetch_ms": feature_fetch_ms}}
 
     # Stage 2b: cross-encoder rerank over the fresh docs.
     t2 = time.perf_counter()
@@ -621,6 +617,11 @@ async def reranked_vector_search_orders(
         "model": payload.get("model"),
         "candidate_count": len(cand),
         "limit": limit,
-        "timings": {"retrieval_ms": retrieval_ms, "feature_fetch_ms": feature_fetch_ms, "rerank_ms": rerank_ms},
+        "timings": {
+            "embed_ms": embed_ms,
+            "recall_ms": recall_ms,
+            "feature_fetch_ms": feature_fetch_ms,
+            "rerank_ms": rerank_ms,
+        },
         "results": reranked,  # full candidate set in reranked order; UI shows top `limit`
     }

--- a/api/src/routes/search.py
+++ b/api/src/routes/search.py
@@ -8,6 +8,7 @@ import asyncio
 import json
 import logging
 import threading
+import time
 from typing import Any, Optional
 
 import httpx
@@ -447,3 +448,160 @@ async def embedding_metrics() -> EmbeddingMetrics:
         skip_ratio=float(value.get("SkipRatio", 0.0)),
         available=True,
     )
+
+
+# ── Cross-encoder reranking ───────────────────────────────────────────────────
+
+RERANK_TIMEOUT = 30.0
+DEFAULT_RERANK_CANDIDATES = 25
+
+
+def _build_rerank_doc(live: dict, line_items: list) -> str:
+    """Assemble the document the cross-encoder reads, from fresh Materialize
+    fields: each item's name, category, live price and stock, plus order status.
+
+    The business signals (price/stock/status) are written into the model input
+    on purpose — they ride along fresh from Materialize. A cross-encoder weights
+    query↔text relevance and may not act on them, but they are in the input.
+    """
+    items = []
+    for it in line_items:
+        name = it.get("product_name")
+        if not name:
+            continue
+        cat = it.get("category") or ""
+        price = it.get("live_price") if it.get("live_price") is not None else it.get("unit_price")
+        stock = it.get("current_stock")
+        attrs = []
+        if cat:
+            attrs.append(cat)
+        if price is not None:
+            try:
+                attrs.append(f"${float(price):.2f}")
+            except (TypeError, ValueError):
+                pass
+        if isinstance(stock, (int, float)):
+            attrs.append("in stock" if stock > 0 else "out of stock")
+        items.append(f"{name} ({', '.join(attrs)})" if attrs else name)
+
+    head = f"Order {live.get('order_number', '')}".strip()
+    status = live.get("order_status")
+    if status:
+        head += f", status {status}"
+    return f"{head}. Items: " + "; ".join(items) if items else head
+
+
+@router.get("/vector/orders/reranked")
+async def reranked_vector_search_orders(
+    q: str = Query(..., min_length=1, description="Natural language search query"),
+    limit: int = Query(default=DEFAULT_SEARCH_LIMIT, ge=1, le=MAX_SEARCH_LIMIT),
+    candidates: int = Query(default=DEFAULT_RERANK_CANDIDATES, ge=5, le=100),
+    service: FreshMartService = Depends(get_freshmart_service),
+) -> dict[str, Any]:
+    """Two-stage retrieval: kNN recall → cross-encoder rerank.
+
+    1. Embed `q`, kNN the top-`candidates` orders from OpenSearch (recall).
+    2. Hydrate each candidate from Materialize and build a fresh document
+       (items + category + live price + stock + status). [feature_fetch_ms]
+    3. Score (query, doc) pairs with the shim's cross-encoder; reorder. [rerank_ms]
+
+    Returns both orderings + each candidate's rerank input/score + stage timings,
+    so the UI can compare kNN vs reranked and show exactly what the model read.
+    """
+    t0 = time.perf_counter()
+    try:
+        async with asyncio.timeout(30):
+            embedder = await asyncio.to_thread(get_query_embedder)
+            vector = (await asyncio.to_thread(embedder.embed, [q]))[0]
+    except asyncio.TimeoutError:
+        raise HTTPException(status_code=503, detail="Embedding model unavailable — check API logs.")
+
+    search_body = {
+        "query": {"knn": {"embedding_text_embedding": {"vector": list(vector), "k": candidates}}},
+        "_source": ["order_id", "embedding_text", "line_items"],
+        "size": candidates,
+    }
+    try:
+        async with httpx.AsyncClient(timeout=OPENSEARCH_TIMEOUT) as client:
+            resp = await client.post(
+                f"{settings.os_url}/orders/_search",
+                json=search_body,
+                headers={"Content-Type": "application/json"},
+            )
+            if resp.status_code == 404:
+                return {"query": q, "model": None, "results": [], "timings": {}}
+            resp.raise_for_status()
+            os_result = resp.json()
+    except httpx.ConnectError:
+        raise HTTPException(status_code=503, detail="OpenSearch is not available.")
+    except httpx.HTTPStatusError as e:
+        raise HTTPException(status_code=502, detail=f"OpenSearch error: {e.response.text}")
+    retrieval_ms = round((time.perf_counter() - t0) * 1000, 1)
+
+    hits = os_result.get("hits", {}).get("hits", []) or []
+    if not hits:
+        return {"query": q, "model": None, "results": [], "timings": {"retrieval_ms": retrieval_ms}}
+
+    # Stage 2a: hydrate candidates from Materialize — the fresh feature fetch.
+    t1 = time.perf_counter()
+
+    async def _hydrate(rank: int, hit: dict) -> dict | None:
+        source = hit.get("_source", {}) or {}
+        order_id = source.get("order_id") or hit.get("_id")
+        if not order_id:
+            return None
+        try:
+            order = await service.get_order(order_id)
+        except Exception:
+            return None
+        if order is None:
+            return None
+        live = order.model_dump(mode="json")
+        line_items = _parse_line_items(source.get("line_items"))
+        return {
+            "order_id": order_id,
+            "order_number": live.get("order_number") or order_id,
+            "status": live.get("order_status"),
+            "knn_score": round(float(hit.get("_score", 0.0)), 4),
+            "original_rank": rank,  # 1-based, in kNN order
+            "doc": _build_rerank_doc(live, line_items),
+        }
+
+    hydrated = await asyncio.gather(*[_hydrate(i + 1, h) for i, h in enumerate(hits)])
+    cand = [c for c in hydrated if c is not None]
+    feature_fetch_ms = round((time.perf_counter() - t1) * 1000, 1)
+    if not cand:
+        return {"query": q, "model": None, "results": [],
+                "timings": {"retrieval_ms": retrieval_ms, "feature_fetch_ms": feature_fetch_ms}}
+
+    # Stage 2b: cross-encoder rerank over the fresh docs.
+    t2 = time.perf_counter()
+    try:
+        async with httpx.AsyncClient(timeout=RERANK_TIMEOUT) as client:
+            rr = await client.post(settings.rerank_url, json={"query": q, "documents": [c["doc"] for c in cand]})
+            rr.raise_for_status()
+            payload = rr.json()
+    except (httpx.HTTPError, ValueError) as e:
+        logger.error("Rerank call failed: %s", e)
+        raise HTTPException(status_code=502, detail=f"Reranker unavailable: {e}")
+    rerank_ms = round((time.perf_counter() - t2) * 1000, 1)
+
+    scores = payload.get("scores") or []
+    if len(scores) != len(cand):
+        raise HTTPException(status_code=502, detail="Reranker returned a mismatched number of scores")
+    for c, s in zip(cand, scores):
+        c["rerank_score"] = round(float(s), 4)
+
+    reranked = sorted(cand, key=lambda c: c["rerank_score"], reverse=True)
+    for new_rank, c in enumerate(reranked, start=1):
+        c["new_rank"] = new_rank
+        c["delta"] = c["original_rank"] - new_rank  # >0 = moved up vs kNN
+
+    return {
+        "query": q,
+        "model": payload.get("model"),
+        "candidate_count": len(cand),
+        "limit": limit,
+        "timings": {"retrieval_ms": retrieval_ms, "feature_fetch_ms": feature_fetch_ms, "rerank_ms": rerank_ms},
+        "results": reranked,  # full candidate set in reranked order; UI shows top `limit`
+    }

--- a/api/src/routes/search.py
+++ b/api/src/routes/search.py
@@ -29,6 +29,9 @@ settings = get_settings()
 DEFAULT_SEARCH_LIMIT = 5
 MAX_SEARCH_LIMIT = 20
 OPENSEARCH_TIMEOUT = 10.0
+# Single budget covering both the embedding model's lazy load and inference,
+# so a query-time embed can't hang the route for two back-to-back timeouts.
+EMBED_TIMEOUT = 30.0
 
 
 def _parse_line_items(value: Any) -> list:
@@ -183,9 +186,8 @@ async def vector_search_orders(
     Orders that no longer exist in Materialize (e.g. deleted) are dropped.
     """
     # 1. Embed query — run in a thread so the model load/inference doesn't block the event loop.
-    # Single 30s budget covers both model load and inference so the route can't hang for 60s.
     try:
-        async with asyncio.timeout(30):
+        async with asyncio.timeout(EMBED_TIMEOUT):
             embedder = await asyncio.to_thread(get_query_embedder)
             vector = (await asyncio.to_thread(embedder.embed, [q]))[0]
     except asyncio.TimeoutError:
@@ -510,7 +512,7 @@ async def reranked_vector_search_orders(
     """
     t0 = time.perf_counter()
     try:
-        async with asyncio.timeout(30):
+        async with asyncio.timeout(EMBED_TIMEOUT):
             embedder = await asyncio.to_thread(get_query_embedder)
             vector = (await asyncio.to_thread(embedder.embed, [q]))[0]
     except asyncio.TimeoutError:
@@ -552,7 +554,8 @@ async def reranked_vector_search_orders(
             return None
         try:
             order = await service.get_order(order_id)
-        except Exception:
+        except Exception as e:
+            logger.warning(f"Failed to hydrate order {order_id} from Materialize: {e}", exc_info=True)
             return None
         if order is None:
             return None

--- a/api/tests/test_rerank_doc.py
+++ b/api/tests/test_rerank_doc.py
@@ -1,0 +1,40 @@
+"""Unit tests for the reranker document builder.
+
+The cross-encoder reads this string per candidate; it must carry the fresh
+business signals (category, live price, stock, status) from Materialize.
+"""
+
+from src.routes.search import _build_rerank_doc
+
+
+def _item(name=None, cat=None, price=None, stock=None):
+    return {"product_name": name, "category": cat, "live_price": price, "current_stock": stock}
+
+
+def test_doc_includes_status_category_price_and_stock():
+    doc = _build_rerank_doc(
+        {"order_number": "FM-1", "order_status": "PICKING"},
+        [_item("Carrots Organic", "Produce", 1.8, 5)],
+    )
+    assert doc.startswith("Order FM-1, status PICKING. Items:")
+    assert "Carrots Organic (Produce, $1.80, in stock)" in doc
+
+
+def test_out_of_stock_and_missing_price():
+    doc = _build_rerank_doc({"order_number": "FM-2"}, [_item("Kale", "Produce", None, 0)])
+    assert "Kale (Produce, out of stock)" in doc
+    assert "$" not in doc  # no price rendered when missing
+
+
+def test_falls_back_to_unit_price_when_no_live_price():
+    doc = _build_rerank_doc({"order_number": "FM-4"}, [{"product_name": "Eggs", "category": "Dairy", "unit_price": 4.99, "current_stock": 2}])
+    assert "Eggs (Dairy, $4.99, in stock)" in doc
+
+
+def test_skips_items_without_a_name():
+    doc = _build_rerank_doc(
+        {"order_number": "FM-3"},
+        [{"category": "Mystery"}, _item("Milk", "Dairy", 2.0, 3)],
+    )
+    assert "Milk (Dairy, $2.00, in stock)" in doc
+    assert "Mystery" not in doc

--- a/api/tests/test_rerank_doc.py
+++ b/api/tests/test_rerank_doc.py
@@ -4,7 +4,7 @@ The cross-encoder reads this string per candidate; it must carry the fresh
 business signals (category, live price, stock, status) from Materialize.
 """
 
-from src.routes.search import _build_rerank_doc
+from src.routes.search import _build_rerank_doc, _build_rerank_doc_parts
 
 
 def _item(name=None, cat=None, price=None, stock=None):
@@ -38,3 +38,27 @@ def test_skips_items_without_a_name():
     )
     assert "Milk (Dairy, $2.00, in stock)" in doc
     assert "Mystery" not in doc
+
+
+def test_parts_split_mz_head_from_indexed_items():
+    """The order head is the Materialize segment; items are the index segment.
+    `doc` must be exactly the two concatenated (what the model scores)."""
+    parts = _build_rerank_doc_parts(
+        {"order_number": "FM-1", "order_status": "PICKING"},
+        [_item("Carrots Organic", "Produce", 1.8, 5)],
+    )
+    assert parts["mz"] == "Order FM-1, status PICKING"
+    assert parts["index"] == "Items: Carrots Organic (Produce, $1.80, in stock)"
+    assert parts["doc"] == f"{parts['mz']}. {parts['index']}"
+    # The string the model reads is unchanged by the split.
+    assert parts["doc"] == _build_rerank_doc(
+        {"order_number": "FM-1", "order_status": "PICKING"},
+        [_item("Carrots Organic", "Produce", 1.8, 5)],
+    )
+
+
+def test_parts_index_empty_when_no_items():
+    """With no line items there's no index segment, and doc is just the head."""
+    parts = _build_rerank_doc_parts({"order_number": "FM-9", "order_status": "CREATED"}, [])
+    assert parts["index"] == ""
+    assert parts["doc"] == parts["mz"] == "Order FM-9, status CREATED"

--- a/api/tests/test_rerank_doc.py
+++ b/api/tests/test_rerank_doc.py
@@ -4,7 +4,7 @@ The cross-encoder reads this string per candidate; it must carry the fresh
 business signals (category, live price, stock, status) from Materialize.
 """
 
-from src.routes.search import _build_rerank_doc, _build_rerank_doc_parts
+from src.routes.search import _build_rerank_doc
 
 
 def _item(name=None, cat=None, price=None, stock=None):
@@ -40,25 +40,15 @@ def test_skips_items_without_a_name():
     assert "Mystery" not in doc
 
 
-def test_parts_split_mz_head_from_indexed_items():
-    """The order head is the Materialize segment; items are the index segment.
-    `doc` must be exactly the two concatenated (what the model scores)."""
-    parts = _build_rerank_doc_parts(
-        {"order_number": "FM-1", "order_status": "PICKING"},
-        [_item("Carrots Organic", "Produce", 1.8, 5)],
+def test_uses_live_price_and_stock_from_materialize_items():
+    """The doc reflects the dynamic price and current stock hydrated from MZ."""
+    doc = _build_rerank_doc(
+        {"order_number": "FM-7", "order_status": "PICKING"},
+        [
+            {"product_name": "Strawberries", "category": "Produce", "live_price": 6.50, "current_stock": 0},
+            {"product_name": "Bananas", "category": "Produce", "live_price": 0.59, "current_stock": 40},
+        ],
     )
-    assert parts["mz"] == "Order FM-1, status PICKING"
-    assert parts["index"] == "Items: Carrots Organic (Produce, $1.80, in stock)"
-    assert parts["doc"] == f"{parts['mz']}. {parts['index']}"
-    # The string the model reads is unchanged by the split.
-    assert parts["doc"] == _build_rerank_doc(
-        {"order_number": "FM-1", "order_status": "PICKING"},
-        [_item("Carrots Organic", "Produce", 1.8, 5)],
-    )
-
-
-def test_parts_index_empty_when_no_items():
-    """With no line items there's no index segment, and doc is just the head."""
-    parts = _build_rerank_doc_parts({"order_number": "FM-9", "order_status": "CREATED"}, [])
-    assert parts["index"] == ""
-    assert parts["doc"] == parts["mz"] == "Order FM-9, status CREATED"
+    assert doc.startswith("Order FM-7, status PICKING. Items:")
+    assert "Strawberries (Produce, $6.50, out of stock)" in doc
+    assert "Bananas (Produce, $0.59, in stock)" in doc

--- a/api/tests/test_search_api.py
+++ b/api/tests/test_search_api.py
@@ -418,7 +418,12 @@ class TestVectorSearchOrdersAPI:
 
     @pytest.mark.asyncio
     async def test_vector_search_response_shape(self, async_client: AsyncClient):
-        """Each result item has order_id, score, embedding_text, embedded_at."""
+        """Each result item has order_id, score, embedding_text, line_items.
+
+        (The server no longer stamps embedded_at — since the perfect-embeddings
+        SMT migration the embed time is observed client-side, so the route's
+        contract is the OS scoring fields + the live Materialize fields.)
+        """
         from src.main import app
         from src.routes.freshmart import get_freshmart_service
 
@@ -460,7 +465,9 @@ class TestVectorSearchOrdersAPI:
         assert "order_id" in item
         assert "score" in item
         assert "embedding_text" in item
-        assert "embedded_at" in item
+        assert "line_items" in item
+        # live Materialize fields are merged in
+        assert "order_status" in item
 
     @pytest.mark.asyncio
     async def test_vector_search_merges_live_data(self, async_client: AsyncClient):

--- a/api/tests/test_search_api.py
+++ b/api/tests/test_search_api.py
@@ -669,3 +669,125 @@ class TestIndexImpactAPI:
             )
         assert response.status_code == 200
         assert response.json()["pct"] == 0.0
+
+
+class TestRerankedVectorSearchAPI:
+    """Tests for GET /api/search/vector/orders/reranked.
+
+    The route makes two sequential posts: first the OpenSearch kNN recall, then
+    the shim's /rerank. We drive both via `mock_post.side_effect` (a 2-item list).
+    """
+
+    @staticmethod
+    def _service_for(order_ids):
+        async def mock_service():
+            svc = AsyncMock()
+
+            async def get_order(oid: str):
+                return _make_mock_order(oid) if oid in order_ids else None
+
+            svc.get_order = AsyncMock(side_effect=get_order)
+            return svc
+
+        return mock_service
+
+    @pytest.mark.asyncio
+    async def test_reranks_candidates_by_cross_encoder_score(self, async_client: AsyncClient):
+        """Candidates are reordered by the shim's scores; deltas reflect the move."""
+        from src.main import app
+        from src.routes.freshmart import get_freshmart_service
+
+        order_ids = ["order:FM-1001", "order:FM-1002"]
+        os_resp = AsyncMock(status_code=200, json=lambda: _make_knn_response(order_ids))
+        os_resp.raise_for_status = lambda: None
+        # kNN order is [FM-1001, FM-1002]; the reranker prefers the second one.
+        rr_resp = AsyncMock(status_code=200, json=lambda: {"model": "x-enc", "scores": [0.10, 0.90]})
+        rr_resp.raise_for_status = lambda: None
+
+        with patch("src.routes.search.get_query_embedder") as mock_get_embedder, \
+                patch("httpx.AsyncClient.post") as mock_post:
+            mock_embedder = MagicMock()
+            mock_embedder.embed.return_value = [[0.1] * 384]
+            mock_get_embedder.return_value = mock_embedder
+            mock_post.side_effect = [os_resp, rr_resp]
+
+            app.dependency_overrides[get_freshmart_service] = self._service_for(order_ids)
+            try:
+                response = await async_client.get(
+                    "/api/search/vector/orders/reranked", params={"q": "produce"}
+                )
+            finally:
+                app.dependency_overrides.clear()
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["model"] == "x-enc"
+        assert data["candidate_count"] == 2
+        results = data["results"]
+        # FM-1002 had the higher rerank score, so it must now be #1 (moved up 1).
+        assert results[0]["order_id"] == "order:FM-1002"
+        assert results[0]["new_rank"] == 1
+        assert results[0]["delta"] == 1
+        assert results[1]["order_id"] == "order:FM-1001"
+        assert results[1]["delta"] == -1
+        assert set(data["timings"]) == {"retrieval_ms", "feature_fetch_ms", "rerank_ms"}
+
+    @pytest.mark.asyncio
+    async def test_score_count_mismatch_returns_502(self, async_client: AsyncClient):
+        """A reranker returning the wrong number of scores is a 502, not a silent crash."""
+        from src.main import app
+        from src.routes.freshmart import get_freshmart_service
+
+        order_ids = ["order:FM-1001", "order:FM-1002"]
+        os_resp = AsyncMock(status_code=200, json=lambda: _make_knn_response(order_ids))
+        os_resp.raise_for_status = lambda: None
+        # Two candidates, but the shim returns a single score.
+        rr_resp = AsyncMock(status_code=200, json=lambda: {"model": "x-enc", "scores": [0.5]})
+        rr_resp.raise_for_status = lambda: None
+
+        with patch("src.routes.search.get_query_embedder") as mock_get_embedder, \
+                patch("httpx.AsyncClient.post") as mock_post:
+            mock_embedder = MagicMock()
+            mock_embedder.embed.return_value = [[0.1] * 384]
+            mock_get_embedder.return_value = mock_embedder
+            mock_post.side_effect = [os_resp, rr_resp]
+
+            app.dependency_overrides[get_freshmart_service] = self._service_for(order_ids)
+            try:
+                response = await async_client.get(
+                    "/api/search/vector/orders/reranked", params={"q": "produce"}
+                )
+            finally:
+                app.dependency_overrides.clear()
+
+        assert response.status_code == 502
+        assert "mismatched number of scores" in response.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_empty_knn_returns_empty_results(self, async_client: AsyncClient):
+        """No kNN hits → empty results without ever calling the reranker."""
+        from src.main import app
+        from src.routes.freshmart import get_freshmart_service
+
+        os_resp = AsyncMock(status_code=200, json=lambda: _make_knn_response([]))
+        os_resp.raise_for_status = lambda: None
+
+        with patch("src.routes.search.get_query_embedder") as mock_get_embedder, \
+                patch("httpx.AsyncClient.post") as mock_post:
+            mock_embedder = MagicMock()
+            mock_embedder.embed.return_value = [[0.1] * 384]
+            mock_get_embedder.return_value = mock_embedder
+            mock_post.side_effect = [os_resp]
+
+            app.dependency_overrides[get_freshmart_service] = self._service_for([])
+            try:
+                response = await async_client.get(
+                    "/api/search/vector/orders/reranked", params={"q": "produce"}
+                )
+            finally:
+                app.dependency_overrides.clear()
+
+        assert response.status_code == 200
+        assert response.json()["results"] == []
+        # Only the OpenSearch post happened — the reranker was never called.
+        assert mock_post.call_count == 1

--- a/api/tests/test_search_api.py
+++ b/api/tests/test_search_api.py
@@ -683,10 +683,18 @@ class TestRerankedVectorSearchAPI:
         async def mock_service():
             svc = AsyncMock()
 
-            async def get_order(oid: str):
-                return _make_mock_order(oid) if oid in order_ids else None
+            async def get_features(oid: str):
+                if oid not in order_ids:
+                    return None
+                return {
+                    "order_number": oid.split(":")[-1],
+                    "order_status": "PICKING",
+                    "line_items": [
+                        {"product_name": "Carrots", "category": "Produce", "live_price": 1.8, "current_stock": 5}
+                    ],
+                }
 
-            svc.get_order = AsyncMock(side_effect=get_order)
+            svc.get_order_with_line_items = AsyncMock(side_effect=get_features)
             return svc
 
         return mock_service
@@ -730,7 +738,10 @@ class TestRerankedVectorSearchAPI:
         assert results[0]["delta"] == 1
         assert results[1]["order_id"] == "order:FM-1001"
         assert results[1]["delta"] == -1
-        assert set(data["timings"]) == {"retrieval_ms", "feature_fetch_ms", "rerank_ms"}
+        # the doc the model scored is the live MZ read; matched_text is the index hit
+        assert "Carrots (Produce, $1.80, in stock)" in results[0]["doc"]
+        assert results[0]["matched_text"]  # embedding_text from the kNN _source
+        assert set(data["timings"]) == {"embed_ms", "recall_ms", "feature_fetch_ms", "rerank_ms"}
 
     @pytest.mark.asyncio
     async def test_score_count_mismatch_returns_502(self, async_client: AsyncClient):

--- a/embeddings-shim/Dockerfile
+++ b/embeddings-shim/Dockerfile
@@ -7,9 +7,11 @@ RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Bake the ONNX weights into the image so the first /v1/embeddings call from
-# the SMT doesn't pay a cold-start download. ~130MB.
+# Bake the ONNX weights into the image so the first request doesn't pay a
+# cold-start download: the embedding model (~130MB) and the cross-encoder
+# reranker (~90MB) used by /rerank.
 RUN python -c "from fastembed import TextEmbedding; TextEmbedding(model_name='BAAI/bge-small-en-v1.5')"
+RUN python -c "from fastembed.rerank.cross_encoder import TextCrossEncoder; TextCrossEncoder(model_name='Xenova/ms-marco-MiniLM-L-6-v2')"
 
 COPY app.py .
 

--- a/embeddings-shim/app.py
+++ b/embeddings-shim/app.py
@@ -30,18 +30,23 @@ import os
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from fastembed import TextEmbedding
+from fastembed.rerank.cross_encoder import TextCrossEncoder
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger("embeddings-shim")
 
 MODEL_NAME = os.environ.get("EMBED_MODEL", "BAAI/bge-small-en-v1.5")
 EMBEDDING_DIM = int(os.environ.get("EMBED_DIM", "384"))
+# Cross-encoder reranker: jointly scores (query, document) pairs. Used by the
+# API's reranked vector search as a precision second stage over the kNN recall.
+RERANK_MODEL = os.environ.get("RERANK_MODEL", "Xenova/ms-marco-MiniLM-L-6-v2")
 
-app = FastAPI(title="Local OpenAI-compatible embeddings", version="1.0.0")
+app = FastAPI(title="Local OpenAI-compatible embeddings + reranker", version="1.0.0")
 
-# Lazy module-level singleton: constructing TextEmbedding downloads/loads the
-# ONNX model (~130MB, ~1s warm-up), so do it once and reuse across requests.
+# Lazy module-level singletons: constructing these downloads/loads ONNX models
+# (~130MB embed, ~90MB rerank), so do it once and reuse across requests.
 _model: TextEmbedding | None = None
+_reranker: TextCrossEncoder | None = None
 
 
 def get_model() -> TextEmbedding:
@@ -52,9 +57,17 @@ def get_model() -> TextEmbedding:
     return _model
 
 
+def get_reranker() -> TextCrossEncoder:
+    global _reranker
+    if _reranker is None:
+        logger.info("Loading cross-encoder reranker: %s", RERANK_MODEL)
+        _reranker = TextCrossEncoder(model_name=RERANK_MODEL)
+    return _reranker
+
+
 @app.get("/health")
 def health() -> dict:
-    return {"status": "ok", "model": MODEL_NAME, "dimensions": EMBEDDING_DIM}
+    return {"status": "ok", "model": MODEL_NAME, "dimensions": EMBEDDING_DIM, "rerank_model": RERANK_MODEL}
 
 
 @app.post("/v1/embeddings")
@@ -90,3 +103,31 @@ async def embeddings(request: Request):
         "data": data,
         "usage": {"prompt_tokens": 0, "total_tokens": 0},
     }
+
+
+@app.post("/rerank")
+async def rerank(request: Request):
+    """Cross-encoder rerank. Returns one relevance score per document, aligned
+    to input order, so the caller can reorder its candidate set.
+
+        request:  {"query": "<text>", "documents": ["<doc>", ...]}
+        response: {"model": "...", "scores": [<float>, ...]}
+    """
+    raw = await request.body()
+    try:
+        payload = json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        payload = {}
+
+    query = payload.get("query")
+    documents = payload.get("documents")
+    if not isinstance(query, str) or not isinstance(documents, list):
+        return JSONResponse(
+            status_code=400,
+            content={"error": "expected {'query': str, 'documents': [str, ...]}"},
+        )
+    if not documents:
+        return {"model": RERANK_MODEL, "scores": []}
+
+    scores = [float(s) for s in get_reranker().rerank(query, documents)]
+    return {"model": RERANK_MODEL, "scores": scores}

--- a/embeddings-shim/app.py
+++ b/embeddings-shim/app.py
@@ -23,6 +23,7 @@ search-sync worker for the Kafka/SMT path without re-indexing.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -129,5 +130,8 @@ async def rerank(request: Request):
     if not documents:
         return {"model": RERANK_MODEL, "scores": []}
 
-    scores = [float(s) for s in get_reranker().rerank(query, documents)]
+    # rerank() is synchronous and CPU-bound — run it off the event loop so a
+    # single inference can't block other requests (mirrors the embed path).
+    raw_scores = await asyncio.to_thread(get_reranker().rerank, query, documents)
+    scores = [float(s) for s in raw_scores]
     return {"model": RERANK_MODEL, "scores": scores}

--- a/embeddings-shim/tests/test_rerank_endpoint.py
+++ b/embeddings-shim/tests/test_rerank_endpoint.py
@@ -1,0 +1,73 @@
+"""Tests for the shim's /rerank endpoint.
+
+The cross-encoder model is replaced with a stub so these run without loading or
+downloading any weights — they exercise the endpoint's contract (validation,
+empty input, score alignment), not the model itself.
+
+Run with:  cd embeddings-shim && pip install -r requirements.txt pytest && pytest
+"""
+
+import os
+import sys
+
+# app.py lives one directory up; put it on the path so `import app` works no
+# matter where pytest is invoked from.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app as shim
+
+
+class _StubReranker:
+    """Returns a descending score per document so order is observable."""
+
+    def rerank(self, query, documents):
+        return [float(len(documents) - i) for i in range(len(documents))]
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setattr(shim, "get_reranker", lambda: _StubReranker())
+    return TestClient(shim.app)
+
+
+def test_returns_one_score_per_document_in_order(client):
+    r = client.post("/rerank", json={"query": "veggies", "documents": ["a", "b", "c"]})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["model"] == shim.RERANK_MODEL
+    assert body["scores"] == [3.0, 2.0, 1.0]  # aligned to input order
+
+
+def test_empty_documents_returns_empty_scores_without_calling_model(client, monkeypatch):
+    # If the model were invoked with no docs it would raise; assert it isn't.
+    def _boom():
+        raise AssertionError("reranker should not be called for empty documents")
+
+    monkeypatch.setattr(shim, "get_reranker", _boom)
+    r = client.post("/rerank", json={"query": "veggies", "documents": []})
+    assert r.status_code == 200
+    assert r.json()["scores"] == []
+
+
+def test_malformed_json_is_rejected(client):
+    r = client.post(
+        "/rerank", content="{not json", headers={"Content-Type": "application/json"}
+    )
+    assert r.status_code == 400
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"documents": ["a"]},               # missing query
+        {"query": "q"},                     # missing documents
+        {"query": 5, "documents": ["a"]},   # query wrong type
+        {"query": "q", "documents": "a"},   # documents wrong type
+    ],
+)
+def test_wrong_types_return_400(client, payload):
+    r = client.post("/rerank", json=payload)
+    assert r.status_code == 400

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -696,6 +696,33 @@ export const searchApi = {
     }),
   embeddingMetrics: () =>
     apiClient.get<EmbeddingMetrics>('/api/search/embedding-metrics'),
+  rerankedVectorSearch: (query: string, limit = 8, candidates = 25) =>
+    apiClient.get<RerankResponse>('/api/search/vector/orders/reranked', {
+      params: { q: query, limit, candidates },
+    }),
+}
+
+// Cross-encoder rerank: each candidate carries its kNN rank/score, the document
+// the model read (assembled fresh from Materialize), and its reranked position.
+export type RerankCandidate = {
+  order_id: string;
+  order_number: string;
+  status: string | null;
+  knn_score: number;
+  original_rank: number;
+  doc: string;
+  rerank_score: number;
+  new_rank: number;
+  delta: number; // >0 moved up vs kNN, <0 moved down
+}
+
+export type RerankResponse = {
+  query: string;
+  model: string | null;
+  candidate_count?: number;
+  limit?: number;
+  timings: { retrieval_ms?: number; feature_fetch_ms?: number; rerank_ms?: number };
+  results: RerankCandidate[];
 }
 
 // Diff counters from the perfect-embeddings SMT (re-embeds skipped vs computed).

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -681,27 +681,6 @@ export type VectorSearchResponse = {
   total: number;
 }
 
-export const searchApi = {
-  searchOrders: (query: string, limit?: number) =>
-    apiClient.get<OpenSearchResponse>('/api/search/orders', {
-      params: { q: query, limit: limit || 5 },
-    }),
-  vectorSearchOrders: (query: string, limit?: number, filters?: { store_zone?: string; order_status?: string }) =>
-    apiClient.get<VectorSearchResponse>('/api/search/vector/orders', {
-      params: { q: query, limit: limit || 3, ...filters },
-    }),
-  indexImpact: (since_mz_timestamp: number) =>
-    apiClient.get<{ impacted: number; total: number; pct: number }>('/api/search/impact', {
-      params: { since_mz_timestamp },
-    }),
-  embeddingMetrics: () =>
-    apiClient.get<EmbeddingMetrics>('/api/search/embedding-metrics'),
-  rerankedVectorSearch: (query: string, limit = 8, candidates = 25) =>
-    apiClient.get<RerankResponse>('/api/search/vector/orders/reranked', {
-      params: { q: query, limit, candidates },
-    }),
-}
-
 // Cross-encoder rerank: each candidate carries its kNN rank/score, the document
 // the model read (assembled fresh from Materialize), and its reranked position.
 export type RerankCandidate = {
@@ -723,6 +702,27 @@ export type RerankResponse = {
   limit?: number;
   timings: { retrieval_ms?: number; feature_fetch_ms?: number; rerank_ms?: number };
   results: RerankCandidate[];
+}
+
+export const searchApi = {
+  searchOrders: (query: string, limit?: number) =>
+    apiClient.get<OpenSearchResponse>('/api/search/orders', {
+      params: { q: query, limit: limit || 5 },
+    }),
+  vectorSearchOrders: (query: string, limit?: number, filters?: { store_zone?: string; order_status?: string }) =>
+    apiClient.get<VectorSearchResponse>('/api/search/vector/orders', {
+      params: { q: query, limit: limit || 3, ...filters },
+    }),
+  indexImpact: (since_mz_timestamp: number) =>
+    apiClient.get<{ impacted: number; total: number; pct: number }>('/api/search/impact', {
+      params: { since_mz_timestamp },
+    }),
+  embeddingMetrics: () =>
+    apiClient.get<EmbeddingMetrics>('/api/search/embedding-metrics'),
+  rerankedVectorSearch: (query: string, limit = 8, candidates = 25) =>
+    apiClient.get<RerankResponse>('/api/search/vector/orders/reranked', {
+      params: { q: query, limit, candidates },
+    }),
 }
 
 // Diff counters from the perfect-embeddings SMT (re-embeds skipped vs computed).

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -689,9 +689,8 @@ export type RerankCandidate = {
   status: string | null;
   knn_score: number;
   original_rank: number;
-  doc: string;        // exact string the model scored (doc_mz + doc_index)
-  doc_mz: string;     // order head (number + status) — live from Materialize
-  doc_index: string;  // line items — from the OpenSearch index ("" if none)
+  doc: string;           // the document the cross-encoder scored — live from Materialize
+  matched_text: string;  // the indexed text kNN matched on — from the OpenSearch index
   rerank_score: number;
   new_rank: number;
   delta: number; // >0 moved up vs kNN, <0 moved down
@@ -702,7 +701,7 @@ export type RerankResponse = {
   model: string | null;
   candidate_count?: number;
   limit?: number;
-  timings: { retrieval_ms?: number; feature_fetch_ms?: number; rerank_ms?: number };
+  timings: { embed_ms?: number; recall_ms?: number; feature_fetch_ms?: number; rerank_ms?: number };
   results: RerankCandidate[];
 }
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -689,7 +689,9 @@ export type RerankCandidate = {
   status: string | null;
   knn_score: number;
   original_rank: number;
-  doc: string;
+  doc: string;        // exact string the model scored (doc_mz + doc_index)
+  doc_mz: string;     // order head (number + status) — live from Materialize
+  doc_index: string;  // line items — from the OpenSearch index ("" if none)
   rerank_score: number;
   new_rank: number;
   delta: number; // >0 moved up vs kNN, <0 moved down

--- a/web/src/components/RerankComparison.test.tsx
+++ b/web/src/components/RerankComparison.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+
+vi.mock('../api/client', () => ({ searchApi: { rerankedVectorSearch: vi.fn() } }))
+
+import { searchApi } from '../api/client'
+import { RerankComparison } from './RerankComparison'
+
+const response = {
+  data: {
+    query: 'veggies',
+    model: 'Xenova/ms-marco-MiniLM-L-6-v2',
+    limit: 8,
+    timings: { retrieval_ms: 12, feature_fetch_ms: 4, rerank_ms: 88 },
+    results: [
+      // already in reranked (new_rank) order
+      { order_id: 'order:FM-000221', order_number: 'FM-000221', status: 'CREATED',
+        knn_score: 0.663, original_rank: 5, doc: 'Order FM-000221. Items: Carrots Organic Bunch (Produce, $1.80, in stock)',
+        rerank_score: 3.83, new_rank: 1, delta: 4 },
+      { order_id: 'order:FM-000472', order_number: 'FM-000472', status: 'PICKING',
+        knn_score: 0.670, original_rank: 1, doc: 'Order FM-000472. Items: Veggie Straws 7oz (Snacks, $4.29, in stock)',
+        rerank_score: 0.11, new_rank: 5, delta: -4 },
+    ],
+  },
+}
+
+describe('RerankComparison', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('renders nothing without a query', () => {
+    const { container } = render(<RerankComparison query="" />)
+    expect(container).toBeEmptyDOMElement()
+    expect(searchApi.rerankedVectorSearch).not.toHaveBeenCalled()
+  })
+
+  it('shows candidates in reranked order with rank deltas, timings, and the doc', async () => {
+    vi.mocked(searchApi.rerankedVectorSearch).mockResolvedValue(response as never)
+    render(<RerankComparison query="veggies" />)
+
+    await waitFor(() => expect(screen.getByText('#FM-000221')).toBeInTheDocument())
+
+    // both candidates rendered, with their reranked positions and deltas
+    expect(screen.getByText('#FM-000472')).toBeInTheDocument()
+    expect(screen.getByText('▲4')).toBeInTheDocument()   // FM-000221 moved up 4
+    expect(screen.getByText('▼4')).toBeInTheDocument()   // FM-000472 moved down 4
+
+    // the document the model read (fresh from MZ) is shown
+    expect(screen.getByText(/Carrots Organic Bunch \(Produce, \$1.80, in stock\)/)).toBeInTheDocument()
+
+    // timing badges, incl. the MZ feature-fetch headline (shown in header + footer)
+    expect(screen.getAllByText('4 ms').length).toBeGreaterThan(0)
+    expect(screen.getByText('88 ms')).toBeInTheDocument()
+    expect(searchApi.rerankedVectorSearch).toHaveBeenCalledWith('veggies')
+  })
+
+  it('shows an error state when the rerank call fails', async () => {
+    vi.mocked(searchApi.rerankedVectorSearch).mockRejectedValue(new Error('down'))
+    render(<RerankComparison query="veggies" />)
+    await waitFor(() => expect(screen.getByText(/Rerank unavailable/i)).toBeInTheDocument())
+  })
+})

--- a/web/src/components/RerankComparison.test.tsx
+++ b/web/src/components/RerankComparison.test.tsx
@@ -47,9 +47,12 @@ describe('RerankComparison', () => {
     // the document the model read (fresh from MZ) is shown
     expect(screen.getByText(/Carrots Organic Bunch \(Produce, \$1.80, in stock\)/)).toBeInTheDocument()
 
-    // timing badges, incl. the MZ feature-fetch headline (shown in header + footer)
-    expect(screen.getAllByText('4 ms').length).toBeGreaterThan(0)
-    expect(screen.getByText('88 ms')).toBeInTheDocument()
+    // stacked latency bar: total + the three stage labels in the legend
+    expect(screen.getByText('response latency')).toBeInTheDocument()
+    expect(screen.getByText('104 ms')).toBeInTheDocument() // 12 + 4 + 88
+    expect(screen.getByText('retrieve')).toBeInTheDocument()
+    expect(screen.getByText('features from MZ')).toBeInTheDocument()
+    expect(screen.getByText('cross-encoder')).toBeInTheDocument()
     expect(searchApi.rerankedVectorSearch).toHaveBeenCalledWith('veggies')
   })
 

--- a/web/src/components/RerankComparison.test.tsx
+++ b/web/src/components/RerankComparison.test.tsx
@@ -15,10 +15,16 @@ const response = {
     results: [
       // already in reranked (new_rank) order
       { order_id: 'order:FM-000221', order_number: 'FM-000221', status: 'CREATED',
-        knn_score: 0.663, original_rank: 5, doc: 'Order FM-000221. Items: Carrots Organic Bunch (Produce, $1.80, in stock)',
+        knn_score: 0.663, original_rank: 5,
+        doc: 'Order FM-000221, status CREATED. Items: Carrots Organic Bunch (Produce, $1.80, in stock)',
+        doc_mz: 'Order FM-000221, status CREATED',
+        doc_index: 'Items: Carrots Organic Bunch (Produce, $1.80, in stock)',
         rerank_score: 3.83, new_rank: 1, delta: 4 },
       { order_id: 'order:FM-000472', order_number: 'FM-000472', status: 'PICKING',
-        knn_score: 0.670, original_rank: 1, doc: 'Order FM-000472. Items: Veggie Straws 7oz (Snacks, $4.29, in stock)',
+        knn_score: 0.670, original_rank: 1,
+        doc: 'Order FM-000472, status PICKING. Items: Veggie Straws 7oz (Snacks, $4.29, in stock)',
+        doc_mz: 'Order FM-000472, status PICKING',
+        doc_index: 'Items: Veggie Straws 7oz (Snacks, $4.29, in stock)',
         rerank_score: 0.11, new_rank: 5, delta: -4 },
     ],
   },
@@ -44,8 +50,11 @@ describe('RerankComparison', () => {
     expect(screen.getByText('▲4')).toBeInTheDocument()   // FM-000221 moved up 4
     expect(screen.getByText('▼4')).toBeInTheDocument()   // FM-000472 moved down 4
 
-    // the document the model read (fresh from MZ) is shown
-    expect(screen.getByText(/Carrots Organic Bunch \(Produce, \$1.80, in stock\)/)).toBeInTheDocument()
+    // the input is split by provenance: MZ-sourced order head + index-sourced items
+    expect(screen.getByText('Order FM-000221, status CREATED')).toBeInTheDocument()
+    expect(screen.getByText(/Items: Carrots Organic Bunch \(Produce, \$1.80, in stock\)/)).toBeInTheDocument()
+    expect(screen.getAllByText('MZ')).toHaveLength(2)      // one per candidate
+    expect(screen.getAllByText('index')).toHaveLength(2)
 
     // stacked latency bar: total + the three stage labels in the legend
     expect(screen.getByText('response latency')).toBeInTheDocument()

--- a/web/src/components/RerankComparison.test.tsx
+++ b/web/src/components/RerankComparison.test.tsx
@@ -11,20 +11,18 @@ const response = {
     query: 'veggies',
     model: 'Xenova/ms-marco-MiniLM-L-6-v2',
     limit: 8,
-    timings: { retrieval_ms: 12, feature_fetch_ms: 4, rerank_ms: 88 },
+    timings: { embed_ms: 30, recall_ms: 12, feature_fetch_ms: 4, rerank_ms: 88 },
     results: [
       // already in reranked (new_rank) order
       { order_id: 'order:FM-000221', order_number: 'FM-000221', status: 'CREATED',
         knn_score: 0.663, original_rank: 5,
         doc: 'Order FM-000221, status CREATED. Items: Carrots Organic Bunch (Produce, $1.80, in stock)',
-        doc_mz: 'Order FM-000221, status CREATED',
-        doc_index: 'Items: Carrots Organic Bunch (Produce, $1.80, in stock)',
+        matched_text: 'Carrots Organic Bunch (Produce)',
         rerank_score: 3.83, new_rank: 1, delta: 4 },
       { order_id: 'order:FM-000472', order_number: 'FM-000472', status: 'PICKING',
         knn_score: 0.670, original_rank: 1,
         doc: 'Order FM-000472, status PICKING. Items: Veggie Straws 7oz (Snacks, $4.29, in stock)',
-        doc_mz: 'Order FM-000472, status PICKING',
-        doc_index: 'Items: Veggie Straws 7oz (Snacks, $4.29, in stock)',
+        matched_text: 'Veggie Straws 7oz (Snacks)',
         rerank_score: 0.11, new_rank: 5, delta: -4 },
     ],
   },
@@ -50,16 +48,17 @@ describe('RerankComparison', () => {
     expect(screen.getByText('▲4')).toBeInTheDocument()   // FM-000221 moved up 4
     expect(screen.getByText('▼4')).toBeInTheDocument()   // FM-000472 moved down 4
 
-    // the input is split by provenance: MZ-sourced order head + index-sourced items
-    expect(screen.getByText('Order FM-000221, status CREATED')).toBeInTheDocument()
-    expect(screen.getByText(/Items: Carrots Organic Bunch \(Produce, \$1.80, in stock\)/)).toBeInTheDocument()
+    // provenance split: [MZ] = the doc the model scored (live), [index] = what kNN matched
+    expect(screen.getByText(/Order FM-000221, status CREATED\. Items: Carrots Organic Bunch \(Produce, \$1.80, in stock\)/)).toBeInTheDocument()
+    expect(screen.getByText(/matched: Carrots Organic Bunch \(Produce\)/)).toBeInTheDocument()
     expect(screen.getAllByText('MZ')).toHaveLength(2)      // one per candidate
     expect(screen.getAllByText('index')).toHaveLength(2)
 
-    // stacked latency bar: total + the three stage labels in the legend
+    // stacked latency bar: total + the four stage labels in the legend
     expect(screen.getByText('response latency')).toBeInTheDocument()
-    expect(screen.getByText('104 ms')).toBeInTheDocument() // 12 + 4 + 88
-    expect(screen.getByText('retrieve')).toBeInTheDocument()
+    expect(screen.getByText('134 ms')).toBeInTheDocument() // 30 + 12 + 4 + 88
+    expect(screen.getByText('embed query')).toBeInTheDocument()
+    expect(screen.getByText('kNN recall')).toBeInTheDocument()
     expect(screen.getByText('features from MZ')).toBeInTheDocument()
     expect(screen.getByText('cross-encoder')).toBeInTheDocument()
     expect(searchApi.rerankedVectorSearch).toHaveBeenCalledWith('veggies')

--- a/web/src/components/RerankComparison.test.tsx
+++ b/web/src/components/RerankComparison.test.tsx
@@ -25,7 +25,7 @@ const response = {
 }
 
 describe('RerankComparison', () => {
-  beforeEach(() => vi.clearAllMocks())
+  beforeEach(() => { vi.clearAllMocks() })
 
   it('renders nothing without a query', () => {
     const { container } = render(<RerankComparison query="" />)
@@ -34,7 +34,7 @@ describe('RerankComparison', () => {
   })
 
   it('shows candidates in reranked order with rank deltas, timings, and the doc', async () => {
-    vi.mocked(searchApi.rerankedVectorSearch).mockResolvedValue(response as never)
+    vi.mocked(searchApi.rerankedVectorSearch).mockResolvedValue(response as any)
     render(<RerankComparison query="veggies" />)
 
     await waitFor(() => expect(screen.getByText('#FM-000221')).toBeInTheDocument())

--- a/web/src/components/RerankComparison.tsx
+++ b/web/src/components/RerankComparison.tsx
@@ -9,6 +9,51 @@ function Delta({ delta }: { delta: number }) {
   return <span className="text-gray-400">—</span>;
 }
 
+// The three pipeline stages, in the order they run, as a proportional stacked bar.
+const STAGES = [
+  { key: "retrieval_ms", label: "retrieve", bar: "bg-gray-300", dot: "bg-gray-300" },
+  { key: "feature_fetch_ms", label: "features from MZ", bar: "bg-purple-500", dot: "bg-purple-500" },
+  { key: "rerank_ms", label: "cross-encoder", bar: "bg-indigo-400", dot: "bg-indigo-400" },
+] as const;
+
+function StageLatency({ timings }: { timings: Record<string, number | undefined> }) {
+  const segs = STAGES.map((s) => ({ ...s, ms: timings[s.key] ?? 0 })).filter((s) => s.ms > 0);
+  const total = segs.reduce((a, s) => a + s.ms, 0);
+  if (!total) return null;
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-1">
+        <span className="text-[11px] text-gray-500">response latency</span>
+        <span className="text-[11px] font-semibold text-gray-700">{fmtMs(Math.round(total))}</span>
+      </div>
+      <div className="flex h-5 w-full rounded overflow-hidden bg-gray-100">
+        {segs.map((s) => {
+          const pct = (s.ms / total) * 100;
+          return (
+            <div
+              key={s.key}
+              className={`${s.bar} flex items-center justify-center overflow-hidden`}
+              style={{ width: `${pct}%` }}
+              title={`${s.label}: ${Math.round(s.ms)} ms (${pct.toFixed(0)}%)`}
+            >
+              {pct >= 16 && <span className="px-1 text-[10px] font-medium text-white truncate">{Math.round(s.ms)}ms</span>}
+            </div>
+          );
+        })}
+      </div>
+      <div className="flex flex-wrap gap-x-4 gap-y-1 mt-1">
+        {segs.map((s) => (
+          <span key={s.key} className="flex items-center gap-1 text-[10px] text-gray-500">
+            <span className={`inline-block w-2 h-2 rounded-sm ${s.dot}`} />
+            <span>{s.label}</span>
+            <span className="font-mono text-gray-400">{Math.round(s.ms)}ms</span>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 /** Two-stage retrieval comparison: kNN recall vs cross-encoder rerank.
  *  Row-per-candidate: ① where kNN ranked it · ② the document the reranker read
  *  (assembled live from Materialize) + the cross-encoder score · ③ new rank. */
@@ -36,14 +81,12 @@ export function RerankComparison({ query }: { query: string }) {
 
   return (
     <div className="border rounded-lg overflow-hidden mt-4">
-      <div className="bg-gray-50 px-4 py-2 border-b flex items-center gap-3 flex-wrap">
-        <span className="text-sm font-medium text-gray-700">Cross-Encoder Rerank</span>
-        {data?.model && <span className="font-mono text-xs text-gray-400">{data.model}</span>}
-        <span className="ml-auto flex items-center gap-3 text-xs text-gray-500">
-          <span>retrieve <b className="text-gray-700">{fmtMs(t.retrieval_ms)}</b></span>
-          <span className="text-purple-700">features from MZ <b>{fmtMs(t.feature_fetch_ms)}</b></span>
-          <span>cross-encoder <b className="text-gray-700">{fmtMs(t.rerank_ms)}</b></span>
-        </span>
+      <div className="bg-gray-50 px-4 py-2 border-b">
+        <div className="flex items-center gap-3 flex-wrap mb-2">
+          <span className="text-sm font-medium text-gray-700">Cross-Encoder Rerank</span>
+          {data?.model && <span className="font-mono text-xs text-gray-400">{data.model}</span>}
+        </div>
+        <StageLatency timings={t} />
       </div>
 
       <div className="p-3 overflow-x-auto">

--- a/web/src/components/RerankComparison.tsx
+++ b/web/src/components/RerankComparison.tsx
@@ -89,7 +89,15 @@ export function RerankComparison({ query }: { query: string }) {
         <StageLatency timings={t} />
       </div>
 
-      <div className="p-3 overflow-x-auto">
+      <div className="p-3 overflow-x-auto relative">
+        {/* A re-query keeps the previous results visible (data is still set);
+            dim them and show a spinner so it's clear a fresh fetch is in flight. */}
+        {loading && data && (
+          <div className="absolute inset-0 z-10 flex items-center justify-center bg-white/60">
+            <span className="text-sm text-gray-500">Reranking…</span>
+          </div>
+        )}
+        <div className={loading && data ? "opacity-40 transition-opacity" : undefined}>
         {loading && !data ? (
           <div className="py-6 text-center text-sm text-gray-500">Reranking…</div>
         ) : error ? (
@@ -136,6 +144,7 @@ export function RerankComparison({ query }: { query: string }) {
           kNN gives the candidate set; the cross-encoder re-scores each on the document above — assembled fresh from
           Materialize (items · category · live price · stock · status) in <b>{fmtMs(t.feature_fetch_ms)}</b>.
         </p>
+        </div>
       </div>
     </div>
   );

--- a/web/src/components/RerankComparison.tsx
+++ b/web/src/components/RerankComparison.tsx
@@ -9,6 +9,22 @@ function Delta({ delta }: { delta: number }) {
   return <span className="text-gray-400">—</span>;
 }
 
+// Provenance badge for the reranker input. Colors echo the latency bar:
+// purple = the live Materialize read (features from MZ), gray = the kNN/index read.
+function Source({ kind }: { kind: "mz" | "index" }) {
+  const mz = kind === "mz";
+  return (
+    <span
+      className={`shrink-0 w-12 text-center rounded px-1 py-0.5 text-[10px] font-semibold border ${
+        mz ? "bg-purple-100 text-purple-700 border-purple-200" : "bg-gray-100 text-gray-500 border-gray-200"
+      }`}
+      title={mz ? "Read live from Materialize at query time" : "Served from the OpenSearch index (kNN stage)"}
+    >
+      {mz ? "MZ" : "index"}
+    </span>
+  );
+}
+
 // The three pipeline stages, in the order they run, as a proportional stacked bar.
 const STAGES = [
   { key: "retrieval_ms", label: "retrieve", bar: "bg-gray-300", dot: "bg-gray-300" },
@@ -110,7 +126,7 @@ export function RerankComparison({ query }: { query: string }) {
               <tr className="text-left text-gray-400 border-b border-gray-100">
                 <th className="pb-1 pr-3 font-medium whitespace-nowrap">Order</th>
                 <th className="pb-1 pr-3 font-medium whitespace-nowrap">① kNN</th>
-                <th className="pb-1 pr-3 font-medium">② Reranker input — doc built live from Materialize</th>
+                <th className="pb-1 pr-3 font-medium">② Reranker input — what the model scored</th>
                 <th className="pb-1 font-medium whitespace-nowrap">③ Reranked</th>
               </tr>
             </thead>
@@ -126,9 +142,21 @@ export function RerankComparison({ query }: { query: string }) {
                     <div className="text-gray-400 font-mono">{c.knn_score.toFixed(3)}</div>
                   </td>
                   <td className="py-2 pr-3">
-                    <code className="block bg-gray-100 text-gray-700 rounded px-2 py-1 leading-relaxed break-words">
-                      {c.doc}
-                    </code>
+                    {/* Same string the model scored, split by provenance:
+                        order head is a live Materialize read, items come from
+                        the search index. Badge colors echo the latency bar. */}
+                    <div className="bg-gray-50 rounded px-2 py-1.5 space-y-1 leading-relaxed">
+                      <div className="flex gap-2">
+                        <Source kind="mz" />
+                        <span className="text-gray-700 break-words">{c.doc_mz}</span>
+                      </div>
+                      {c.doc_index && (
+                        <div className="flex gap-2">
+                          <Source kind="index" />
+                          <span className="text-gray-700 break-words">{c.doc_index}</span>
+                        </div>
+                      )}
+                    </div>
                     <span className="text-gray-500">x-enc <b className="text-purple-700 font-mono">{c.rerank_score.toFixed(2)}</b></span>
                   </td>
                   <td className="py-2 whitespace-nowrap">
@@ -141,8 +169,9 @@ export function RerankComparison({ query }: { query: string }) {
           </table>
         )}
         <p className="mt-2 text-xs text-gray-400">
-          kNN gives the candidate set; the cross-encoder re-scores each on the document above — assembled fresh from
-          Materialize (items · category · live price · stock · status) in <b>{fmtMs(t.feature_fetch_ms)}</b>.
+          Each input is two reads: the <span className="text-purple-600 font-medium">order head</span> is fetched live
+          from Materialize (<b>{fmtMs(t.feature_fetch_ms)}</b>), the <span className="text-gray-500 font-medium">line
+          items</span> come from the search index alongside the kNN hit. The cross-encoder re-scores the concatenation.
         </p>
         </div>
       </div>

--- a/web/src/components/RerankComparison.tsx
+++ b/web/src/components/RerankComparison.tsx
@@ -18,16 +18,20 @@ function Source({ kind }: { kind: "mz" | "index" }) {
       className={`shrink-0 w-12 text-center rounded px-1 py-0.5 text-[10px] font-semibold border ${
         mz ? "bg-purple-100 text-purple-700 border-purple-200" : "bg-gray-100 text-gray-500 border-gray-200"
       }`}
-      title={mz ? "Read live from Materialize at query time" : "Served from the OpenSearch index (kNN stage)"}
+      title={mz
+        ? "The document the cross-encoder scored — read live from Materialize at query time"
+        : "The text kNN matched on — embedded at index time (recall only, not scored)"}
     >
       {mz ? "MZ" : "index"}
     </span>
   );
 }
 
-// The three pipeline stages, in the order they run, as a proportional stacked bar.
+// The pipeline stages, in the order they run, as a proportional stacked bar.
+// embed + kNN recall are split out so a cold model load doesn't look like slow retrieval.
 const STAGES = [
-  { key: "retrieval_ms", label: "retrieve", bar: "bg-gray-300", dot: "bg-gray-300" },
+  { key: "embed_ms", label: "embed query", bar: "bg-sky-300", dot: "bg-sky-300" },
+  { key: "recall_ms", label: "kNN recall", bar: "bg-gray-300", dot: "bg-gray-300" },
   { key: "feature_fetch_ms", label: "features from MZ", bar: "bg-purple-500", dot: "bg-purple-500" },
   { key: "rerank_ms", label: "cross-encoder", bar: "bg-indigo-400", dot: "bg-indigo-400" },
 ] as const;
@@ -119,14 +123,14 @@ export function RerankComparison({ query }: { query: string }) {
         ) : error ? (
           <div className="py-6 text-center text-sm text-red-600">{error}</div>
         ) : rows.length === 0 ? (
-          <div className="py-6 text-center text-sm text-gray-500">No results.</div>
+          <div className="py-6 text-center text-sm text-gray-500">No candidates to rerank.</div>
         ) : (
           <table className="w-full border-collapse" style={{ fontSize: "12px" }}>
             <thead>
               <tr className="text-left text-gray-400 border-b border-gray-100">
                 <th className="pb-1 pr-3 font-medium whitespace-nowrap">Order</th>
                 <th className="pb-1 pr-3 font-medium whitespace-nowrap">① kNN</th>
-                <th className="pb-1 pr-3 font-medium">② Reranker input — what the model scored</th>
+                <th className="pb-1 pr-3 font-medium">② Reranker input — scored doc (MZ) vs what kNN matched (index)</th>
                 <th className="pb-1 font-medium whitespace-nowrap">③ Reranked</th>
               </tr>
             </thead>
@@ -142,18 +146,21 @@ export function RerankComparison({ query }: { query: string }) {
                     <div className="text-gray-400 font-mono">{c.knn_score.toFixed(3)}</div>
                   </td>
                   <td className="py-2 pr-3">
-                    {/* Same string the model scored, split by provenance:
-                        order head is a live Materialize read, items come from
-                        the search index. Badge colors echo the latency bar. */}
-                    <div className="bg-gray-50 rounded px-2 py-1.5 space-y-1 leading-relaxed">
+                    {/* Two sources, color-matched to the latency bar:
+                        [MZ] the document the cross-encoder actually scores, read
+                        live from Materialize; [index] the text kNN matched on,
+                        embedded at index time (recall only, not scored). */}
+                    <div className="bg-gray-50 rounded px-2 py-1.5 space-y-1.5 leading-relaxed">
                       <div className="flex gap-2">
                         <Source kind="mz" />
-                        <span className="text-gray-700 break-words">{c.doc_mz}</span>
+                        <span className="text-gray-700 break-words">{c.doc}</span>
                       </div>
-                      {c.doc_index && (
+                      {c.matched_text && (
                         <div className="flex gap-2">
                           <Source kind="index" />
-                          <span className="text-gray-700 break-words">{c.doc_index}</span>
+                          <span className="text-gray-400 break-words italic">
+                            matched: {c.matched_text}
+                          </span>
                         </div>
                       )}
                     </div>
@@ -169,9 +176,10 @@ export function RerankComparison({ query }: { query: string }) {
           </table>
         )}
         <p className="mt-2 text-xs text-gray-400">
-          Each input is two reads: the <span className="text-purple-600 font-medium">order head</span> is fetched live
-          from Materialize (<b>{fmtMs(t.feature_fetch_ms)}</b>), the <span className="text-gray-500 font-medium">line
-          items</span> come from the search index alongside the kNN hit. The cross-encoder re-scores the concatenation.
+          OpenSearch picks the candidates by matching <span className="text-gray-500 font-medium">indexed text</span> (kNN
+          recall). The cross-encoder then scores a <span className="text-purple-600 font-medium">document read live from
+          Materialize</span> — status, items, current price and stock, hydrated in <b>{fmtMs(t.feature_fetch_ms)}</b> — so
+          editing a triple changes the ranking immediately, before the index catches up.
         </p>
         </div>
       </div>

--- a/web/src/components/RerankComparison.tsx
+++ b/web/src/components/RerankComparison.tsx
@@ -1,0 +1,101 @@
+import { useState, useEffect } from "react";
+import { searchApi, RerankResponse } from "../api/client";
+
+const fmtMs = (ms?: number) => (ms == null ? "—" : `${ms} ms`);
+
+function Delta({ delta }: { delta: number }) {
+  if (delta > 0) return <span className="text-green-600 font-semibold">▲{delta}</span>;
+  if (delta < 0) return <span className="text-red-500 font-semibold">▼{-delta}</span>;
+  return <span className="text-gray-400">—</span>;
+}
+
+/** Two-stage retrieval comparison: kNN recall vs cross-encoder rerank.
+ *  Row-per-candidate: ① where kNN ranked it · ② the document the reranker read
+ *  (assembled live from Materialize) + the cross-encoder score · ③ new rank. */
+export function RerankComparison({ query }: { query: string }) {
+  const [data, setData] = useState<RerankResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!query) { setData(null); return; }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    searchApi.rerankedVectorSearch(query)
+      .then((r) => { if (!cancelled) setData(r.data); })
+      .catch(() => { if (!cancelled) setError("Rerank unavailable — ensure the embeddings service is running."); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [query]);
+
+  if (!query) return null;
+
+  const rows = (data?.results ?? []).slice(0, data?.limit ?? 8);
+  const t = data?.timings ?? {};
+
+  return (
+    <div className="border rounded-lg overflow-hidden mt-4">
+      <div className="bg-gray-50 px-4 py-2 border-b flex items-center gap-3 flex-wrap">
+        <span className="text-sm font-medium text-gray-700">Cross-Encoder Rerank</span>
+        {data?.model && <span className="font-mono text-xs text-gray-400">{data.model}</span>}
+        <span className="ml-auto flex items-center gap-3 text-xs text-gray-500">
+          <span>retrieve <b className="text-gray-700">{fmtMs(t.retrieval_ms)}</b></span>
+          <span className="text-purple-700">features from MZ <b>{fmtMs(t.feature_fetch_ms)}</b></span>
+          <span>cross-encoder <b className="text-gray-700">{fmtMs(t.rerank_ms)}</b></span>
+        </span>
+      </div>
+
+      <div className="p-3 overflow-x-auto">
+        {loading && !data ? (
+          <div className="py-6 text-center text-sm text-gray-500">Reranking…</div>
+        ) : error ? (
+          <div className="py-6 text-center text-sm text-red-600">{error}</div>
+        ) : rows.length === 0 ? (
+          <div className="py-6 text-center text-sm text-gray-500">No results.</div>
+        ) : (
+          <table className="w-full border-collapse" style={{ fontSize: "12px" }}>
+            <thead>
+              <tr className="text-left text-gray-400 border-b border-gray-100">
+                <th className="pb-1 pr-3 font-medium whitespace-nowrap">Order</th>
+                <th className="pb-1 pr-3 font-medium whitespace-nowrap">① kNN</th>
+                <th className="pb-1 pr-3 font-medium">② Reranker input — doc built live from Materialize</th>
+                <th className="pb-1 font-medium whitespace-nowrap">③ Reranked</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((c) => (
+                <tr key={c.order_id} className="border-b border-gray-100 last:border-0 align-top">
+                  <td className="py-2 pr-3 font-semibold text-gray-900 whitespace-nowrap">
+                    #{c.order_number}
+                    {c.status && <div className="text-gray-400 font-normal">{c.status}</div>}
+                  </td>
+                  <td className="py-2 pr-3 text-gray-600 whitespace-nowrap">
+                    #{c.original_rank}
+                    <div className="text-gray-400 font-mono">{c.knn_score.toFixed(3)}</div>
+                  </td>
+                  <td className="py-2 pr-3">
+                    <code className="block bg-gray-100 text-gray-700 rounded px-2 py-1 leading-relaxed break-words">
+                      {c.doc}
+                    </code>
+                    <span className="text-gray-500">x-enc <b className="text-purple-700 font-mono">{c.rerank_score.toFixed(2)}</b></span>
+                  </td>
+                  <td className="py-2 whitespace-nowrap">
+                    <span className="font-semibold text-gray-900">#{c.new_rank}</span>{" "}
+                    <Delta delta={c.delta} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+        <p className="mt-2 text-xs text-gray-400">
+          kNN gives the candidate set; the cross-encoder re-scores each on the document above — assembled fresh from
+          Materialize (items · category · live price · stock · status) in <b>{fmtMs(t.feature_fetch_ms)}</b>.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default RerankComparison;

--- a/web/src/components/VectorPipelineCard.test.tsx
+++ b/web/src/components/VectorPipelineCard.test.tsx
@@ -6,6 +6,11 @@ import { VectorPipelineCard } from './VectorPipelineCard'
 vi.mock('../api/client', () => ({
   searchApi: {
     vectorSearchOrders: vi.fn(),
+    // RerankComparison renders whenever a query is submitted and calls this;
+    // return an empty result set so it shows "No results." without erroring.
+    rerankedVectorSearch: vi.fn().mockResolvedValue({
+      data: { query: '', model: null, timings: {}, results: [] },
+    }),
     // The embedding-metrics ticker polls this; return an unavailable payload so
     // the ticker stays hidden and existing assertions are unaffected.
     embeddingMetrics: vi.fn().mockResolvedValue({

--- a/web/src/components/VectorPipelineCard.tsx
+++ b/web/src/components/VectorPipelineCard.tsx
@@ -191,7 +191,6 @@ export const VectorPipelineCard = ({ defaultExpanded = false }: { defaultExpande
   const [writeTrigger, setWriteTrigger]     = useState<{ mzLowerBound: number; wallClock: number } | null>(null);
   const [filterZone, setFilterZone]         = useState("");
   const [filterStatus, setFilterStatus]     = useState("");
-  const [rerankOn, setRerankOn]             = useState(false);
 
   // Keyed by order_id so they survive result reordering
   const prevPricesRef     = useRef<Record<string, Record<number, number>>>({});
@@ -362,15 +361,6 @@ export const VectorPipelineCard = ({ defaultExpanded = false }: { defaultExpande
                   <option value="OUT_FOR_DELIVERY">OUT_FOR_DELIVERY</option>
                   <option value="DELIVERED">DELIVERED</option>
                 </select>
-                <label className="ml-auto flex items-center gap-1.5 text-xs text-gray-600 cursor-pointer select-none">
-                  <input
-                    type="checkbox"
-                    checked={rerankOn}
-                    onChange={e => setRerankOn(e.target.checked)}
-                    className="accent-purple-600"
-                  />
-                  Rerank (cross-encoder)
-                </label>
               </div>
               <div className="text-xs text-gray-500">
                 Try:{" "}
@@ -441,7 +431,7 @@ export const VectorPipelineCard = ({ defaultExpanded = false }: { defaultExpande
             </div>
           </div>
 
-          {rerankOn && submittedQuery && <RerankComparison query={submittedQuery} />}
+          {submittedQuery && <RerankComparison query={submittedQuery} />}
 
         </div>
       )}

--- a/web/src/components/VectorPipelineCard.tsx
+++ b/web/src/components/VectorPipelineCard.tsx
@@ -8,6 +8,7 @@ import {
 import { searchApi, VectorSearchResult, VectorLineItem } from "../api/client";
 import { WriteTripleForm } from "./WriteTripleForm";
 import { SearchIndexUpdates } from "./SearchIndexUpdates";
+import { RerankComparison } from "./RerankComparison";
 
 // ── Embedding fingerprint ─────────────────────────────────────────────────────
 
@@ -190,6 +191,7 @@ export const VectorPipelineCard = ({ defaultExpanded = false }: { defaultExpande
   const [writeTrigger, setWriteTrigger]     = useState<{ mzLowerBound: number; wallClock: number } | null>(null);
   const [filterZone, setFilterZone]         = useState("");
   const [filterStatus, setFilterStatus]     = useState("");
+  const [rerankOn, setRerankOn]             = useState(false);
 
   // Keyed by order_id so they survive result reordering
   const prevPricesRef     = useRef<Record<string, Record<number, number>>>({});
@@ -360,6 +362,15 @@ export const VectorPipelineCard = ({ defaultExpanded = false }: { defaultExpande
                   <option value="OUT_FOR_DELIVERY">OUT_FOR_DELIVERY</option>
                   <option value="DELIVERED">DELIVERED</option>
                 </select>
+                <label className="ml-auto flex items-center gap-1.5 text-xs text-gray-600 cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    checked={rerankOn}
+                    onChange={e => setRerankOn(e.target.checked)}
+                    className="accent-purple-600"
+                  />
+                  Rerank (cross-encoder)
+                </label>
               </div>
               <div className="text-xs text-gray-500">
                 Try:{" "}
@@ -430,6 +441,7 @@ export const VectorPipelineCard = ({ defaultExpanded = false }: { defaultExpande
             </div>
           </div>
 
+          {rerankOn && submittedQuery && <RerankComparison query={submittedQuery} />}
 
         </div>
       )}


### PR DESCRIPTION
## What

Adds a second, precision stage to vector search: **kNN recall → cross-encoder rerank**, with a 3-column UI comparing the two orderings and showing exactly what the reranker read.

- **`embeddings-shim`** — new `POST /rerank` using fastembed `TextCrossEncoder` (`Xenova/ms-marco-MiniLM-L-6-v2`); `{query, documents[]}` → `{scores[]}`. Model pre-baked into the image.
- **API** — `GET /api/search/vector/orders/reranked`: kNN top-25 → hydrate each candidate from Materialize → build a per-candidate document with fresh context (items · category · live price · stock · status) → cross-encoder scores `(query, doc)` → reorder. Returns both orderings + per-candidate inputs/scores + stage timings (`retrieval_ms` / `feature_fetch_ms` / `rerank_ms`).
- **Web** — `RerankComparison` (row-per-candidate: ① kNN rank/score · ② the live-from-MZ document the model read + its cross-encoder score · ③ reranked rank + Δ), behind a **Rerank (cross-encoder)** toggle on the Vector Pipeline card.

## The Materialize angle

Reranking re-reads each candidate's *document* at query time. Here that document is **assembled fresh from Materialize in a ~ms read** (surfaced as the `features from MZ` timing) — the thing that's slow/stale without an always-fresh read model. Edit a triple → the document changes → the reranked order updates live.

## Honest note on the model (validated, not assumed)

I tested the cross-encoder directly. `ms-marco-MiniLM` is **relevance-on-text and lexical-leaning**: for "veggies" it ranks "Veggie Straws (Snacks)" highly on the token overlap, and flipping a doc to "out of stock" barely moves its score. So per your call, the business signals (price/stock/status) **ride into the model input fresh from MZ**, but the cross-encoder weights query↔text relevance and may not act strongly on them. Query phrasing matters — e.g. "organic vegetables" cleanly promotes produce and demotes the snack. The UI shows the real reorder, no cherry-picking.

## Tests / validation

- `RerankComparison.test.tsx` (mocked) + `_build_rerank_doc` unit tests; 18 web tests pass.
- `/rerank` validated against a built shim image (cross-encoder loads + scores).
- Full endpoint e2e needs a deploy (the shim image gains the reranker model, and the API gains the new route).

🤖 Generated with [Claude Code](https://claude.com/claude-code)