### PR TITLE
Fix silent "Write a Triple" no-op from connection-pool starvation

### DIFF
--- a/web/src/api/client.config.test.ts
+++ b/web/src/api/client.config.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// Capture the config passed to axios.create when the client module is imported.
+vi.mock('axios', () => ({
+  default: {
+    create: vi.fn(() => ({
+      get: vi.fn(),
+      post: vi.fn(),
+      put: vi.fn(),
+      delete: vi.fn(),
+    })),
+  },
+}))
+
+import axios from 'axios'
+import { API_TIMEOUT_MS } from './client'
+
+describe('apiClient configuration', () => {
+  it('configures a request timeout so stalled requests reject instead of hanging', () => {
+    expect(API_TIMEOUT_MS).toBeGreaterThan(0)
+    expect(vi.mocked(axios.create)).toHaveBeenCalledWith(
+      expect.objectContaining({ timeout: API_TIMEOUT_MS }),
+    )
+  })
+})

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -12,8 +12,15 @@ const getApiUrl = (): string => {
 
 const API_URL = getApiUrl();
 
+// Default request timeout (ms). Without this, a stalled request (e.g. a slow or
+// half-open SSH tunnel to a remote backend) hangs forever instead of rejecting,
+// holding its socket open. Fixed-interval pollers can then exhaust the browser's
+// per-origin connection pool and silently stall unrelated requests like writes.
+export const API_TIMEOUT_MS = 15000;
+
 export const apiClient = axios.create({
   baseURL: API_URL,
+  timeout: API_TIMEOUT_MS,
   headers: {
     'Content-Type': 'application/json',
   },

--- a/web/src/api/singleFlight.test.ts
+++ b/web/src/api/singleFlight.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest'
+import { singleFlight } from './singleFlight'
+
+// A deferred promise we can resolve manually to control when an in-flight call settles.
+function deferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>((r) => { resolve = r })
+  return { promise, resolve }
+}
+
+describe('singleFlight', () => {
+  it('skips overlapping calls while one is in flight', async () => {
+    const d = deferred()
+    const fn = vi.fn(() => d.promise)
+    const guarded = singleFlight(fn)
+
+    guarded() // starts the in-flight call
+    guarded() // should be skipped
+    guarded() // should be skipped
+
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    d.resolve()
+    await Promise.resolve()
+  })
+
+  it('allows a new call once the previous one settles', async () => {
+    let d = deferred()
+    const fn = vi.fn(() => d.promise)
+    const guarded = singleFlight(fn)
+
+    const first = guarded()
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    d.resolve()
+    await first
+
+    d = deferred()
+    fn.mockImplementation(() => d.promise)
+    guarded()
+    expect(fn).toHaveBeenCalledTimes(2)
+    d.resolve()
+  })
+
+  it('clears the in-flight flag even when the wrapped fn rejects', async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(undefined)
+    const guarded = singleFlight(fn)
+
+    await expect(guarded()).rejects.toThrow('boom')
+
+    // A rejection must not leave the guard stuck — the next call should run.
+    await guarded()
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('forwards arguments to the wrapped fn', async () => {
+    const fn = vi.fn(async (_a: string, _b: number) => {})
+    const guarded = singleFlight(fn)
+
+    await guarded('a', 1)
+    expect(fn).toHaveBeenCalledWith('a', 1)
+  })
+})

--- a/web/src/api/singleFlight.ts
+++ b/web/src/api/singleFlight.ts
@@ -1,0 +1,25 @@
+/**
+ * Wraps an async function so that overlapping invocations are skipped while a
+ * previous call is still in flight.
+ *
+ * Fixed-interval pollers (setInterval) fire on a fixed cadence regardless of how
+ * long each call takes. If the backend/tunnel slows down so a call takes longer
+ * than the interval, requests pile up faster than they drain and can exhaust the
+ * browser's per-origin HTTP connection pool — which then stalls unrelated
+ * requests (like a triple write) indefinitely. Guarding the poller so at most one
+ * call is ever in flight prevents that pile-up.
+ */
+export function singleFlight<Args extends unknown[]>(
+  fn: (...args: Args) => Promise<void>,
+): (...args: Args) => Promise<void> {
+  let inFlight = false;
+  return async (...args: Args) => {
+    if (inFlight) return;
+    inFlight = true;
+    try {
+      await fn(...args);
+    } finally {
+      inFlight = false;
+    }
+  };
+}

--- a/web/src/components/WriteTripleForm.test.tsx
+++ b/web/src/components/WriteTripleForm.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { WriteTripleForm } from './WriteTripleForm'
+import { queryStatsApi } from '../api/client'
+
+vi.mock('lucide-react', () => ({
+  Edit3: () => <div>Edit3</div>,
+}))
+
+vi.mock('../api/client', () => ({
+  queryStatsApi: {
+    writeTriple: vi.fn(),
+  },
+}))
+
+const writeTriple = vi.mocked(queryStatsApi.writeTriple)
+
+// Fill the form so the Write button becomes enabled, then click it.
+const fillAndSubmit = (value = '5') => {
+  fireEvent.change(screen.getByPlaceholderText('order:FM-1001'), {
+    target: { value: 'order:FM-000503' },
+  })
+  // Predicate defaults to "quantity"; its placeholder is "5".
+  const valueInput = screen.getByPlaceholderText('5')
+  fireEvent.change(valueInput, { target: { value } })
+  fireEvent.click(screen.getByRole('button', { name: 'Write' }))
+}
+
+describe('WriteTripleForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('disables the Write button until subject, predicate, and value are all set', () => {
+    render(<WriteTripleForm />)
+    const button = screen.getByRole('button', { name: 'Write' })
+    expect(button).toBeDisabled()
+
+    fireEvent.change(screen.getByPlaceholderText('order:FM-1001'), {
+      target: { value: 'order:FM-000503' },
+    })
+    // Still disabled — value is empty.
+    expect(button).toBeDisabled()
+
+    fireEvent.change(screen.getByPlaceholderText('5'), { target: { value: '5' } })
+    expect(button).toBeEnabled()
+  })
+
+  it('flashes a success message on a successful write', async () => {
+    writeTriple.mockResolvedValueOnce({
+      data: { mz_timestamp_lower_bound: 123 },
+    } as never)
+
+    render(<WriteTripleForm />)
+    fillAndSubmit()
+
+    await waitFor(() => {
+      expect(screen.getByText(/^Written at/)).toBeInTheDocument()
+    })
+    expect(writeTriple).toHaveBeenCalledWith({
+      subject_id: 'order:FM-000503',
+      predicate: 'quantity',
+      object_value: '5',
+    })
+  })
+
+  it('surfaces the backend error detail instead of a generic failure', async () => {
+    writeTriple.mockRejectedValueOnce({
+      isAxiosError: true,
+      message: 'Request failed with status code 404',
+      response: { data: { detail: 'Triple not found: order:FM-000503 / quantity' } },
+    })
+
+    render(<WriteTripleForm />)
+    fillAndSubmit()
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Error: Triple not found: order:FM-000503 / quantity'),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('reports a timeout clearly when the request is aborted', async () => {
+    writeTriple.mockRejectedValueOnce({
+      isAxiosError: true,
+      code: 'ECONNABORTED',
+      message: 'timeout of 15000ms exceeded',
+    })
+
+    render(<WriteTripleForm />)
+    fillAndSubmit()
+
+    await waitFor(() => {
+      expect(screen.getByText(/Timed out/)).toBeInTheDocument()
+    })
+  })
+})

--- a/web/src/components/WriteTripleForm.tsx
+++ b/web/src/components/WriteTripleForm.tsx
@@ -1,6 +1,21 @@
 import { useState, useEffect, useMemo } from "react";
+import axios from "axios";
 import { Edit3 } from "lucide-react";
 import { queryStatsApi } from "../api/client";
+
+// Turn a thrown write error into a human-readable message. Previously every
+// failure surfaced a generic "Write failed", and a stalled request produced no
+// feedback at all — making a hung write look like a no-op.
+const describeWriteError = (err: unknown): string => {
+  if (axios.isAxiosError(err)) {
+    if (err.code === "ECONNABORTED" || err.code === "ETIMEDOUT") {
+      return "Timed out — backend may be slow or unreachable";
+    }
+    const detail = (err.response?.data as { detail?: string } | undefined)?.detail;
+    return detail ?? err.message;
+  }
+  return "Write failed";
+};
 
 const predicatesBySubjectType: Record<string, string[]> = {
   order: ['order_status', 'order_number', 'delivery_window_start', 'delivery_window_end'],
@@ -73,8 +88,8 @@ export const WriteTripleForm = ({ initialSubject = "", onWritten, onWriteComplet
       if (res.data.mz_timestamp_lower_bound != null) {
         onWriteComplete?.(res.data.mz_timestamp_lower_bound, Date.now() / 1000);
       }
-    } catch {
-      flash("Write failed");
+    } catch (err) {
+      flash(`Error: ${describeWriteError(err)}`);
     }
   };
 

--- a/web/src/pages/QueryStatisticsPage.tsx
+++ b/web/src/pages/QueryStatisticsPage.tsx
@@ -39,6 +39,7 @@ import {
   OrderLineItem,
   ViewDefinitionResponse,
 } from "../api/client";
+import { singleFlight } from "../api/singleFlight";
 import { LineageGraph } from "../components/LineageGraph";
 import { WhatAreTriplesCard } from "../components/WhatAreTriplesCard";
 import { WhatIsKnowledgeGraphCard } from "../components/WhatIsKnowledgeGraphCard";
@@ -791,6 +792,11 @@ export default function QueryStatisticsPage() {
     }
   }, []);
 
+  // Guard the 1s poller so at most one batch of metric requests is ever in flight.
+  // Without this, a slow backend/tunnel lets ticks pile up faster than they drain
+  // and exhaust the browser's per-origin connection pool, stalling writes.
+  const fetchMetricsGuarded = useMemo(() => singleFlight(fetchMetrics), [fetchMetrics]);
+
   // Start polling
   const handleStartPolling = async () => {
     if (!selectedOrderId) return;
@@ -806,9 +812,9 @@ export default function QueryStatisticsPage() {
       setOrderData(null);
 
       // Start fetching metrics every second
-      metricsIntervalRef.current = window.setInterval(fetchMetrics, 1000);
+      metricsIntervalRef.current = window.setInterval(fetchMetricsGuarded, 1000);
       // Fetch immediately
-      fetchMetrics();
+      fetchMetricsGuarded();
     } catch (err) {
       console.error("Failed to start polling:", err);
       setError("Failed to start polling");

--- a/web/src/pages/QueryStatisticsPage.tsx
+++ b/web/src/pages/QueryStatisticsPage.tsx
@@ -795,7 +795,13 @@ export default function QueryStatisticsPage() {
   // Guard the 1s poller so at most one batch of metric requests is ever in flight.
   // Without this, a slow backend/tunnel lets ticks pile up faster than they drain
   // and exhaust the browser's per-origin connection pool, stalling writes.
-  const fetchMetricsGuarded = useMemo(() => singleFlight(fetchMetrics), [fetchMetrics]);
+  // useRef lazy-init guarantees exactly one guard per component instance, stable
+  // across re-renders regardless of whether fetchMetrics' identity ever changes.
+  const fetchMetricsGuardedRef = useRef<(() => Promise<void>) | null>(null);
+  if (fetchMetricsGuardedRef.current === null) {
+    fetchMetricsGuardedRef.current = singleFlight(fetchMetrics);
+  }
+  const fetchMetricsGuarded = fetchMetricsGuardedRef.current;
 
   // Start polling
   const handleStartPolling = async () => {

--- a/web/src/pages/QueryStatisticsPage.tsx
+++ b/web/src/pages/QueryStatisticsPage.tsx
@@ -795,11 +795,15 @@ export default function QueryStatisticsPage() {
   // Guard the 1s poller so at most one batch of metric requests is ever in flight.
   // Without this, a slow backend/tunnel lets ticks pile up faster than they drain
   // and exhaust the browser's per-origin connection pool, stalling writes.
-  // useRef lazy-init guarantees exactly one guard per component instance, stable
-  // across re-renders regardless of whether fetchMetrics' identity ever changes.
+  //
+  // "latest-ref" pattern: the guard wrapper is created once per mount (stable inFlight
+  // flag), but always delegates to fetchMetricsLatestRef.current so it calls the
+  // current closure even if fetchMetrics gains dependencies in the future.
+  const fetchMetricsLatestRef = useRef(fetchMetrics);
+  fetchMetricsLatestRef.current = fetchMetrics;
   const fetchMetricsGuardedRef = useRef<(() => Promise<void>) | null>(null);
   if (fetchMetricsGuardedRef.current === null) {
-    fetchMetricsGuardedRef.current = singleFlight(fetchMetrics);
+    fetchMetricsGuardedRef.current = singleFlight(() => fetchMetricsLatestRef.current());
   }
   const fetchMetricsGuarded = fetchMetricsGuardedRef.current;
 


### PR DESCRIPTION
## Problem

On the main query-stats page (`/`), clicking **Write** in the "Write a Triple" form would sometimes do nothing — no success flash, no error flash. A page refresh made the next write work. The backend was healthy and warm; the bug was entirely client-side.

## Root cause

A hung request that never resolved *or* rejected, caused by three compounding issues:

1. **No axios timeout** (`client.ts`) — a stalled request (e.g. a slow or half-open SSH tunnel to a remote/EC2 backend) hangs forever and keeps its socket open.
2. **Unbounded polling** (`QueryStatisticsPage.tsx`) — the page polls metrics every 1s, firing **3 concurrent GETs per tick** (`getMetrics` / `getMetricsHistory` / `getOrderData`) with no in-flight guard. When the tunnel/backend slows, ticks pile up faster than they drain and saturate the browser's **6-connections-per-origin** HTTP/1.1 limit. The write `POST` then queues behind the stuck GETs and — with no timeout — never completes. Refreshing tears down the stuck sockets, which is why it "fixed" itself.
3. **Swallowed errors** (`WriteTripleForm.tsx`) — the `catch` collapsed everything to a generic "Write failed", and on a true hang produced no feedback at all.

## Changes

- **Add a 15s default timeout** to the axios client so stalled requests reject and free their socket. This protects *every* poller in the app, not just this form.
- **Add `singleFlight()`** and wrap the 1s metrics poller so at most one batch is ever in flight — the pile-up can't happen.
- **Surface the real write error** (backend `detail`, or a clear "Timed out" message) instead of the generic string, so a future stall is visible rather than a silent no-op.

## Tests

- `singleFlight.test.ts` — skips overlapping calls, resumes after settle, clears its flag on rejection, forwards args.
- `client.config.test.ts` — asserts the axios client is created with a timeout.
- `WriteTripleForm.test.tsx` — disabled-until-filled gating, success flash, backend-detail surfacing, and timeout (`ECONNABORTED`) messaging.

All 9 new tests pass. No regressions: the suite has 131 pre-existing failures on `main` (they require a live API); this branch is identical at 131 failed and adds the 9 new passing tests. (Note: `npm run lint` is broken repo-wide — no ESLint config file is present — pre-existing and unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)