### PR TITLE
Force-merge the orders index on /vector-search load to keep kNN recall healthy

### DIFF
--- a/api/src/routes/search.py
+++ b/api/src/routes/search.py
@@ -335,6 +335,56 @@ async def get_index_stats() -> dict[str, Any]:
         raise HTTPException(status_code=500, detail=str(e))
 
 
+# ── Force-merge (kNN recall maintenance) ──────────────────────────────────────
+# This demo deliberately keeps the frequently-changing price/stock fields in the
+# search doc so a single triple edit visibly updates a complex document — it's a
+# narrative choice, not a perf one. The cost: every order change UPSERTs the doc
+# and tombstones the prior Lucene version, and in a knn_vector index those dead
+# vectors linger in the per-segment HNSW graph. Once the deleted ratio is high,
+# approximate kNN traversal gets swamped by tombstones and recall collapses to a
+# handful of hits. Expunging deletes rebuilds the graph over only-live vectors.
+# The vector-search page triggers this on load so recall stays healthy live.
+FORCEMERGE_INDEX = "orders"
+FORCEMERGE_TIMEOUT = 60.0
+# Skip if we merged this recently — rapid reloads / StrictMode double-invokes
+# shouldn't stack merges (OpenSearch serializes them per shard anyway).
+FORCEMERGE_MIN_INTERVAL_S = 15.0
+
+_forcemerge_lock = asyncio.Lock()
+_forcemerge_last_run = 0.0
+
+
+@router.post("/force-merge")
+async def force_merge_search_index() -> dict[str, Any]:
+    """Expunge deleted docs from the orders index to keep kNN recall healthy.
+
+    Called when the vector-search page loads. Single-flight + debounced so rapid
+    reloads don't pile up merges. Degrades gracefully (never raises) so a merge
+    hiccup can't block the page from rendering.
+    """
+    global _forcemerge_last_run
+    if _forcemerge_lock.locked():
+        return {"triggered": False, "reason": "in_progress"}
+    if time.monotonic() - _forcemerge_last_run < FORCEMERGE_MIN_INTERVAL_S:
+        return {"triggered": False, "reason": "debounced"}
+    async with _forcemerge_lock:
+        # Re-check inside the lock to close the check-then-act race.
+        if time.monotonic() - _forcemerge_last_run < FORCEMERGE_MIN_INTERVAL_S:
+            return {"triggered": False, "reason": "debounced"}
+        try:
+            async with httpx.AsyncClient(timeout=FORCEMERGE_TIMEOUT) as client:
+                resp = await client.post(
+                    f"{settings.os_url}/{FORCEMERGE_INDEX}/_forcemerge",
+                    params={"only_expunge_deletes": "true"},
+                )
+                resp.raise_for_status()
+            _forcemerge_last_run = time.monotonic()
+            return {"triggered": True}
+        except httpx.HTTPError as e:
+            logger.warning("force-merge of %s failed: %s", FORCEMERGE_INDEX, e)
+            return {"triggered": False, "reason": "error"}
+
+
 IMPACT_INDEXES = ["orders", "inventory"]
 
 

--- a/api/tests/test_search_api.py
+++ b/api/tests/test_search_api.py
@@ -809,3 +809,74 @@ class TestRerankedVectorSearchAPI:
         assert response.json()["results"] == []
         # Only the OpenSearch post happened — the reranker was never called.
         assert mock_post.call_count == 1
+
+
+class TestForceMergeAPI:
+    """Tests for POST /api/search/force-merge (kNN recall maintenance)."""
+
+    @staticmethod
+    def _mock_os_client(post_mock):
+        """Build a patch target for the route's outbound httpx.AsyncClient.
+
+        Patching the module's `httpx.AsyncClient` (rather than the class method)
+        avoids intercepting the test client's own POST to the app.
+        """
+        instance = MagicMock()
+        instance.__aenter__ = AsyncMock(return_value=instance)
+        instance.__aexit__ = AsyncMock(return_value=False)
+        instance.post = post_mock
+        return patch("src.routes.search.httpx.AsyncClient", return_value=instance)
+
+    @pytest.mark.asyncio
+    async def test_force_merge_triggers_expunge_deletes(self, async_client: AsyncClient):
+        """A first call expunges deletes on the orders index and reports triggered."""
+        import src.routes.search as search
+
+        search._forcemerge_last_run = 0.0  # bypass debounce
+        resp_ok = MagicMock(status_code=200)
+        resp_ok.raise_for_status = lambda: None
+        post_mock = AsyncMock(return_value=resp_ok)
+
+        with self._mock_os_client(post_mock):
+            response = await async_client.post("/api/search/force-merge")
+
+        assert response.status_code == 200
+        assert response.json() == {"triggered": True}
+        # Hit the orders force-merge endpoint with only_expunge_deletes.
+        url = post_mock.call_args.args[0]
+        params = post_mock.call_args.kwargs["params"]
+        assert url.endswith("/orders/_forcemerge")
+        assert params == {"only_expunge_deletes": "true"}
+
+    @pytest.mark.asyncio
+    async def test_force_merge_debounced_within_interval(self, async_client: AsyncClient):
+        """A call soon after a prior merge is skipped without touching OpenSearch."""
+        import time
+
+        import src.routes.search as search
+
+        search._forcemerge_last_run = time.monotonic()  # just ran
+        post_mock = AsyncMock()
+
+        with self._mock_os_client(post_mock) as os_client:
+            response = await async_client.post("/api/search/force-merge")
+
+        assert response.status_code == 200
+        assert response.json() == {"triggered": False, "reason": "debounced"}
+        os_client.assert_not_called()  # no merge attempted
+
+    @pytest.mark.asyncio
+    async def test_force_merge_degrades_on_opensearch_error(self, async_client: AsyncClient):
+        """An OpenSearch failure never raises — the page must still render."""
+        import httpx
+
+        import src.routes.search as search
+
+        search._forcemerge_last_run = 0.0
+        post_mock = AsyncMock(side_effect=httpx.ConnectError("refused"))
+
+        with self._mock_os_client(post_mock):
+            response = await async_client.post("/api/search/force-merge")
+
+        assert response.status_code == 200
+        assert response.json() == {"triggered": False, "reason": "error"}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -731,6 +731,10 @@ export const searchApi = {
     apiClient.get<RerankResponse>('/api/search/vector/orders/reranked', {
       params: { q: query, limit, candidates },
     }),
+  // Expunge deleted docs from the orders index so kNN recall stays healthy.
+  // Server-side single-flight + debounced; safe to call on every page load.
+  forceMergeSearchIndex: () =>
+    apiClient.post<{ triggered: boolean; reason?: string }>('/api/search/force-merge'),
 }
 
 // Diff counters from the perfect-embeddings SMT (re-embeds skipped vs computed).

--- a/web/src/pages/VectorSearchPage.test.tsx
+++ b/web/src/pages/VectorSearchPage.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import VectorSearchPage from './VectorSearchPage'
+import { searchApi } from '../api/client'
+
+// VectorPipelineCard pulls in heavy search/chart deps; stub it out.
+vi.mock('../components/VectorPipelineCard', () => ({
+  VectorPipelineCard: () => <div data-testid="vector-pipeline-card" />,
+}))
+
+vi.mock('../api/client', () => ({
+  searchApi: {
+    forceMergeSearchIndex: vi.fn(() => Promise.resolve({ data: { triggered: true } })),
+  },
+}))
+
+const forceMerge = vi.mocked(searchApi.forceMergeSearchIndex)
+
+describe('VectorSearchPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('triggers a force-merge when the page loads', async () => {
+    render(<VectorSearchPage />)
+    await waitFor(() => {
+      expect(forceMerge).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('still renders if the force-merge request rejects', async () => {
+    forceMerge.mockRejectedValueOnce(new Error('network'))
+    const { getByTestId } = render(<VectorSearchPage />)
+    // The page must not crash on a failed/slow merge — it is fire-and-forget.
+    expect(getByTestId('vector-pipeline-card')).toBeInTheDocument()
+    await waitFor(() => expect(forceMerge).toHaveBeenCalled())
+  })
+})

--- a/web/src/pages/VectorSearchPage.tsx
+++ b/web/src/pages/VectorSearchPage.tsx
@@ -1,6 +1,16 @@
+import { useEffect } from "react";
 import { VectorPipelineCard } from "../components/VectorPipelineCard";
+import { searchApi } from "../api/client";
 
 export default function VectorSearchPage() {
+  // Keep kNN recall healthy for the demo: each order change UPSERTs (and thus
+  // tombstones) the search doc, and dead vectors swamp the HNSW graph until a
+  // merge expunges them. Expunge deletes on load. Fire-and-forget + debounced
+  // server-side, so a slow/failed merge never blocks the page.
+  useEffect(() => {
+    searchApi.forceMergeSearchIndex().catch(() => {});
+  }, []);
+
   return (
     <div className="p-6 max-w-5xl mx-auto">
       <div className="mb-6">


### PR DESCRIPTION
## Problem

Searching the vector-search demo (e.g. \"veggies\") would return only ~1–2 results instead of the usual many. Root cause was **deleted-doc bloat strangling approximate kNN**:

- The `orders` index had 504 live docs but **~9,300 tombstoned docs** across its segments (some 100% deleted).
- Approximate kNN traverses the per-segment HNSW graph, collects the `k` nearest *graph nodes*, then drops tombstoned ones **after** retrieval. With ~95% of the graph dead, almost every neighbor found was a tombstone → recall collapsed to ~2 hits.

This demo intentionally keeps frequently-changing price/stock fields in the search doc — so a single triple edit visibly updates a complex document (the "small change updates complex things" narrative). The cost is that *every* order change UPSERTs the doc and tombstones the prior Lucene version, and those dead vectors linger in the HNSW graph until a merge expunges them. `deletes_pct_allowed=10` (from #122) is set on the index, but background merges don't keep up under heavy write churn.

## Fix

Expunge deletes on demand, tied to the page that needs healthy recall:

- **New `POST /api/search/force-merge`** runs `_forcemerge?only_expunge_deletes=true` on the orders index, rebuilding the HNSW graph over only-live vectors. It's **single-flight** (`asyncio.Lock`) and **debounced** (`FORCEMERGE_MIN_INTERVAL_S = 15s`) so rapid reloads / React StrictMode double-invokes don't stack merges. It **degrades gracefully** — never raises.
- **`VectorSearchPage`** fires it once on mount (fire-and-forget), so a slow or failed merge can't block the page from rendering.

Verified manually against the live stack: `only_expunge_deletes=true` collapsed the bloated segments to a single clean segment (504 live / 0 deleted) and raw kNN recall went from **2 → 25** hits.

## Tests

- Backend (`TestForceMergeAPI`): triggers expunge-deletes with the correct URL/params; debounces a quick second call without touching OpenSearch; degrades to `{triggered: false, reason: "error"}` on an OpenSearch failure. Full search suite: 32 passed.
- Frontend (`VectorSearchPage.test.tsx`): asserts the merge fires on load, and that the page still renders if the request rejects.

## Notes

- Debounce state is per-process; under a multi-worker deployment each worker may merge once. Harmless (OpenSearch serializes force-merges per shard) and fine for a demo.
- This is the on-demand backstop #122's README already described — now automated for the demo flow rather than the structural "don't re-UPSERT on non-embedded changes" fix, which is intentionally declined here to preserve the live-price narrative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)